### PR TITLE
feat(infra): dev 백엔드 최초 배포 스택 구현

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,29 @@
+# GuardBench dev Terraform runbook
+
+이 디렉터리는 `guardbench-dev` 최초 백엔드 배포를 선언한다. `apply` 전에 AWS 실제 리소스와 remote state를 비교한다. 이미 배포된 VPC, subnet, ALB, CloudFront, S3, VPC Endpoint, Security Group, Target Group은 재생성하지 않는다.
+
+## 준비
+
+1. Terraform 1.10 이상과 `ap-northeast-2` AWS credential을 준비한다.
+2. `terraform.tfvars.example`을 복사하여 `app_image_tag`에 `clean check bootBuildImage`를 통과한 backend commit SHA를 넣는다.
+3. `terraform init -input=false` 후 `terraform state list`를 실행한다.
+4. state에 없는 기존 리소스만 해당 Terraform address로 import한다. import 대상과 ID는 적용 직전에 AWS 조회 결과로 확정한다.
+
+```bash
+terraform import aws_vpc.main vpc-...
+terraform import 'aws_subnet.public[0]' subnet-...
+terraform import aws_lb.main arn:aws:elasticloadbalancing:...
+terraform import aws_cloudfront_distribution.frontend DISTRIBUTION_ID
+```
+
+## 배포 순서
+
+```bash
+terraform fmt -check
+terraform validate
+terraform plan -out=tfplan
+```
+
+계획에서 기존 네트워크, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다.
+
+ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -31,11 +31,11 @@ resource "aws_lb_target_group" "api" {
 
   health_check {
     enabled             = true
-    path                = "/health"
+    path                = "/api/v1/test-suites"
     port                = "traffic-port"
     protocol            = "HTTP"
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     timeout             = 5
     interval            = 30
     matcher             = "200"

--- a/terraform/cloudfront-s3.tf
+++ b/terraform/cloudfront-s3.tf
@@ -40,8 +40,8 @@ resource "aws_s3_bucket_policy" "frontend" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid       = "AllowCloudFrontOAC"
-        Effect    = "Allow"
+        Sid    = "AllowCloudFrontOAC"
+        Effect = "Allow"
         Principal = {
           Service = "cloudfront.amazonaws.com"
         }
@@ -94,7 +94,7 @@ resource "aws_cloudfront_distribution" "frontend" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
@@ -128,17 +128,8 @@ resource "aws_cloudfront_distribution" "frontend" {
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
 
-    forwarded_values {
-      query_string = true
-      headers      = ["Authorization", "Origin", "Accept"]
-      cookies {
-        forward = "all"
-      }
-    }
-
-    min_ttl     = 0
-    default_ttl = 0 # API는 캐싱하지 않음
-    max_ttl     = 0
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id
   }
 
   # SPA 클라이언트 라우팅: 404 → index.html 반환
@@ -170,4 +161,12 @@ resource "aws_cloudfront_distribution" "frontend" {
   tags = {
     Name = "${var.project}-${var.environment}-frontend-cf"
   }
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host_header" {
+  name = "Managed-AllViewerExceptHostHeader"
 }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,12 +1,12 @@
 # ============================================
 # ECR Repository (컨테이너 이미지 저장소)
-# 3개 서비스가 하나의 이미지를 공유, 실행 명령으로 역할 구분
+# 단일 App Service가 HTTP API와 비동기 worker를 함께 실행한다.
 # ============================================
 
 resource "aws_ecr_repository" "app" {
   name                 = "${var.project}-${var.environment}"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = var.environment != "prod"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
 
   image_scanning_configuration {
     scan_on_push = true

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,11 +1,5 @@
-# ============================================
-# ECS Cluster + API Service + Worker Services
-# api: ALB 뒤에서 REST 서빙
-# orchestrator: SQS 폴링 (gb-run-resolve, gb-run-finalize)
-# executor: SQS 폴링 (gb-workitems)
-# ============================================
+data "aws_caller_identity" "current" {}
 
-# --- ECS Cluster ---
 resource "aws_ecs_cluster" "main" {
   name = "${var.project}-${var.environment}-cluster"
 
@@ -19,31 +13,19 @@ resource "aws_ecs_cluster" "main" {
   }
 }
 
-# --- CloudWatch Log Groups ---
-resource "aws_cloudwatch_log_group" "api" {
-  name              = "/ecs/${var.project}-${var.environment}/api"
-  retention_in_days = 30
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${var.project}-${var.environment}/app"
+  retention_in_days = 14
 }
 
-resource "aws_cloudwatch_log_group" "orchestrator" {
-  name              = "/ecs/${var.project}-${var.environment}/orchestrator"
-  retention_in_days = 30
-}
-
-resource "aws_cloudwatch_log_group" "executor" {
-  name              = "/ecs/${var.project}-${var.environment}/executor"
-  retention_in_days = 30
-}
-
-# --- IAM: Task Execution Role (이미지 pull, 로그, SSM 읽기) ---
 resource "aws_iam_role" "ecs_task_execution" {
   name = "${var.project}-${var.environment}-ecs-exec-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
       Principal = { Service = "ecs-tasks.amazonaws.com" }
     }]
   })
@@ -54,67 +36,36 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-resource "aws_iam_role_policy" "ecs_exec_ssm" {
-  name = "${var.project}-${var.environment}-ecs-exec-ssm"
+resource "aws_iam_role_policy" "ecs_exec_secrets" {
+  name = "${var.project}-${var.environment}-ecs-exec-secrets"
   role = aws_iam_role.ecs_task_execution.id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
       Effect   = "Allow"
-      Action   = ["ssm:GetParameters", "ssm:GetParameter"]
-      Resource = "arn:aws:ssm:${var.aws_region}:*:parameter/${var.project}/${var.environment}/*"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = aws_db_instance.app.master_user_secret[0].secret_arn
     }]
   })
 }
 
-# --- IAM: API Task Role ---
-resource "aws_iam_role" "api_task" {
-  name = "${var.project}-${var.environment}-api-task-role"
+resource "aws_iam_role" "app_task" {
+  name = "${var.project}-${var.environment}-app-task-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
       Principal = { Service = "ecs-tasks.amazonaws.com" }
     }]
   })
 }
 
-resource "aws_iam_role_policy" "api_task" {
-  name = "${var.project}-${var.environment}-api-task-policy"
-  role = aws_iam_role.api_task.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["sqs:SendMessage"]
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-# --- IAM: Worker Task Role (orchestrator + executor) ---
-resource "aws_iam_role" "worker_task" {
-  name = "${var.project}-${var.environment}-worker-task-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = { Service = "ecs-tasks.amazonaws.com" }
-    }]
-  })
-}
-
-resource "aws_iam_role_policy" "worker_task" {
-  name = "${var.project}-${var.environment}-worker-task-policy"
-  role = aws_iam_role.worker_task.id
+resource "aws_iam_role_policy" "app_task" {
+  name = "${var.project}-${var.environment}-app-task-policy"
+  role = aws_iam_role.app_task.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -122,43 +73,42 @@ resource "aws_iam_role_policy" "worker_task" {
       {
         Effect = "Allow"
         Action = [
+          "sqs:SendMessage",
           "sqs:ReceiveMessage",
           "sqs:DeleteMessage",
-          "sqs:GetQueueAttributes",
-          "sqs:SendMessage"
         ]
-        Resource = "*"
+        Resource = values(aws_sqs_queue.source)[*].arn
       },
       {
         Effect = "Allow"
         Action = [
+          "bedrock:CreateGuardrailVersion",
           "bedrock:ApplyGuardrail",
-          "bedrock:GetGuardrail",
-          "bedrock:CreateGuardrailVersion"
         ]
-        Resource = "*"
-      }
+        Resource = "arn:aws:bedrock:${var.aws_region}:${data.aws_caller_identity.current.account_id}:guardrail/*"
+      },
     ]
   })
 }
 
-# ============================================
-# Task Definitions
-# ============================================
-
-# API Task Definition
-resource "aws_ecs_task_definition" "api" {
-  family                   = "${var.project}-${var.environment}-api"
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.project}-${var.environment}-app"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.api_cpu
   memory                   = var.api_memory
-  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
-  task_role_arn            = aws_iam_role.api_task.arn
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  execution_role_arn = aws_iam_role.ecs_task_execution.arn
+  task_role_arn      = aws_iam_role.app_task.arn
 
   container_definitions = jsonencode([{
-    name      = "api"
-    image     = "${aws_ecr_repository.app.repository_url}:latest"
+    name      = "app"
+    image     = "${aws_ecr_repository.app.repository_url}:${var.app_image_tag}"
     essential = true
 
     portMappings = [{
@@ -167,91 +117,39 @@ resource "aws_ecs_task_definition" "api" {
     }]
 
     environment = [
-      { name = "SERVICE_ROLE", value = "api" },
       { name = "SERVER_PORT", value = tostring(var.api_container_port) },
+      { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${aws_db_instance.app.address}:${var.db_port}/guardbench?sslmode=require" },
+      { name = "AWS_REGION", value = var.aws_region },
+      { name = "SQS_ENABLED", value = "true" },
+      { name = "WORKER_ENABLED", value = "true" },
+      { name = "SPRING_TASK_SCHEDULING_POOL_SIZE", value = "4" },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RESOLVE", value = aws_sqs_queue.source["gb-run-resolve"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_WORK_ITEMS", value = aws_sqs_queue.source["gb-workitems"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RUN_FINALIZE", value = aws_sqs_queue.source["gb-run-finalize"].url },
+    ]
+
+    secrets = [
+      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:username::" },
+      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:password::" },
     ]
 
     logConfiguration = {
       logDriver = "awslogs"
       options = {
-        "awslogs-group"         = aws_cloudwatch_log_group.api.name
+        "awslogs-group"         = aws_cloudwatch_log_group.app.name
         "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "api"
+        "awslogs-stream-prefix" = "app"
       }
     }
   }])
 }
 
-# Orchestrator Task Definition
-resource "aws_ecs_task_definition" "orchestrator" {
-  family                   = "${var.project}-${var.environment}-orchestrator"
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = var.worker_cpu
-  memory                   = var.worker_memory
-  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
-  task_role_arn            = aws_iam_role.worker_task.arn
-
-  container_definitions = jsonencode([{
-    name      = "orchestrator"
-    image     = "${aws_ecr_repository.app.repository_url}:latest"
-    essential = true
-
-    environment = [
-      { name = "SERVICE_ROLE", value = "orchestrator" },
-    ]
-
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        "awslogs-group"         = aws_cloudwatch_log_group.orchestrator.name
-        "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "orchestrator"
-      }
-    }
-  }])
-}
-
-# Executor Task Definition
-resource "aws_ecs_task_definition" "executor" {
-  family                   = "${var.project}-${var.environment}-executor"
-  network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                      = var.worker_cpu
-  memory                   = var.worker_memory
-  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
-  task_role_arn            = aws_iam_role.worker_task.arn
-
-  container_definitions = jsonencode([{
-    name      = "executor"
-    image     = "${aws_ecr_repository.app.repository_url}:latest"
-    essential = true
-
-    environment = [
-      { name = "SERVICE_ROLE", value = "executor" },
-    ]
-
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        "awslogs-group"         = aws_cloudwatch_log_group.executor.name
-        "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "executor"
-      }
-    }
-  }])
-}
-
-# ============================================
-# ECS Services
-# ============================================
-
-# API Service (ALB 연결)
-resource "aws_ecs_service" "api" {
-  name            = "${var.project}-${var.environment}-api"
+resource "aws_ecs_service" "app" {
+  name            = "${var.project}-${var.environment}-app"
   cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.api.arn
-  desired_count   = var.api_desired_count
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.app_desired_count
   launch_type     = "FARGATE"
 
   network_configuration {
@@ -262,14 +160,12 @@ resource "aws_ecs_service" "api" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.api.arn
-    container_name   = "api"
+    container_name   = "app"
     container_port   = var.api_container_port
   }
 
-  deployment_configuration {
-    minimum_healthy_percent = 50
-    maximum_percent         = 200
-  }
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
 
   deployment_circuit_breaker {
     enable   = true
@@ -277,56 +173,4 @@ resource "aws_ecs_service" "api" {
   }
 
   depends_on = [aws_lb_listener.http]
-
-  lifecycle {
-    ignore_changes = [desired_count, task_definition]
-  }
-}
-
-# Orchestrator Service (SQS 폴링, ALB 없음)
-resource "aws_ecs_service" "orchestrator" {
-  name            = "${var.project}-${var.environment}-orchestrator"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.orchestrator.arn
-  desired_count   = var.worker_desired_count
-  launch_type     = "FARGATE"
-
-  network_configuration {
-    subnets          = aws_subnet.private[*].id
-    security_groups  = [aws_security_group.worker.id]
-    assign_public_ip = false
-  }
-
-  deployment_circuit_breaker {
-    enable   = true
-    rollback = true
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count, task_definition]
-  }
-}
-
-# Executor Service (SQS 폴링, ALB 없음)
-resource "aws_ecs_service" "executor" {
-  name            = "${var.project}-${var.environment}-executor"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.executor.arn
-  desired_count   = var.worker_desired_count
-  launch_type     = "FARGATE"
-
-  network_configuration {
-    subnets          = aws_subnet.private[*].id
-    security_groups  = [aws_security_group.worker.id]
-    assign_public_ip = false
-  }
-
-  deployment_circuit_breaker {
-    enable   = true
-    rollback = true
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count, task_definition]
-  }
 }

--- a/terraform/observability.tf
+++ b/terraform/observability.tf
@@ -1,0 +1,97 @@
+resource "aws_sns_topic" "ops" {
+  name = "${var.project}-${var.environment}-ops"
+}
+
+resource "aws_sns_topic_subscription" "ops_email" {
+  count = var.alarm_email == null ? 0 : 1
+
+  topic_arn = aws_sns_topic.ops.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+resource "aws_cloudwatch_log_metric_filter" "app_error" {
+  name           = "${var.project}-${var.environment}-app-error"
+  log_group_name = aws_cloudwatch_log_group.app.name
+  pattern        = "?ERROR ?Exception"
+
+  metric_transformation {
+    name          = "AppErrorCount"
+    namespace     = "GuardBench/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_error" {
+  alarm_name          = "${var.project}-${var.environment}-app-errors"
+  alarm_description   = "Application error log entries were detected."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.app_error.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.app_error.metric_transformation[0].namespace
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.ops.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_cpu" {
+  alarm_name          = "${var.project}-${var.environment}-app-cpu"
+  alarm_description   = "Combined ECS app service CPU is above 80 percent."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.ops.arn]
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.app.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "queue_oldest_message" {
+  for_each = aws_sqs_queue.source
+
+  alarm_name          = "${var.project}-${var.environment}-${each.key}-oldest-message"
+  alarm_description   = "The oldest source queue message has been waiting for over one minute."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateAgeOfOldestMessage"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 60
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.ops.arn]
+
+  dimensions = {
+    QueueName = each.value.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "dead_letter_visible_messages" {
+  for_each = aws_sqs_queue.dead_letter
+
+  alarm_name          = "${var.project}-${var.environment}-${each.key}-dlq-messages"
+  alarm_description   = "A dead-letter queue contains one or more messages."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.ops.arn]
+
+  dimensions = {
+    QueueName = each.value.name
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -75,6 +75,21 @@ output "ecr_repository_url" {
   value       = aws_ecr_repository.app.repository_url
 }
 
+output "rds_endpoint" {
+  description = "Private PostgreSQL endpoint for the combined app service"
+  value       = aws_db_instance.app.address
+}
+
+output "sqs_queue_urls" {
+  description = "Source queue URLs injected into the app task definition"
+  value       = { for name, queue in aws_sqs_queue.source : name => queue.url }
+}
+
+output "ops_sns_topic_arn" {
+  description = "Operations alarm topic; email subscriptions require confirmation"
+  value       = aws_sns_topic.ops.arn
+}
+
 # ============================================
 # Security Group Outputs
 # ============================================
@@ -89,7 +104,7 @@ output "api_security_group_id" {
 }
 
 output "worker_security_group_id" {
-  description = "Worker (orchestrator/executor) security group ID"
+  description = "Preserved worker security group ID; not attached during the first dev deployment"
   value       = aws_security_group.worker.id
 }
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,38 @@
+resource "aws_db_subnet_group" "app" {
+  name       = "${var.project}-${var.environment}-db-subnets"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${var.project}-${var.environment}-db-subnets"
+  }
+}
+
+resource "aws_db_instance" "app" {
+  identifier = "${var.project}-${var.environment}"
+
+  engine         = "postgres"
+  engine_version = "16.14"
+  instance_class = "db.t4g.micro"
+  db_name        = "guardbench"
+  username       = "guardbench"
+
+  manage_master_user_password = true
+  storage_encrypted           = true
+  storage_type                = "gp3"
+  allocated_storage           = 20
+  max_allocated_storage       = 100
+
+  db_subnet_group_name   = aws_db_subnet_group.app.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  backup_retention_period    = 1
+  auto_minor_version_upgrade = true
+  deletion_protection        = false
+  skip_final_snapshot        = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-postgres"
+  }
+}

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -140,19 +140,18 @@ resource "aws_security_group" "vpc_endpoints" {
   description = "GuardBench VPC Endpoints - allow HTTPS from private subnets"
   vpc_id      = aws_vpc.main.id
 
+  # 기존 state가 inline ingress를 소유한다. API만 남겨 Worker 접근을 제거한다.
+  ingress {
+    description     = "HTTPS from the combined app service"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.api.id]
+  }
+
   tags = {
     Name = "${var.project}-${var.environment}-vpce-sg"
   }
-}
-
-resource "aws_security_group_rule" "vpc_endpoints_ingress_from_api" {
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.api.id
-  description              = "HTTPS from the combined app service"
-  security_group_id        = aws_security_group.vpc_endpoints.id
 }
 
 data "aws_ec2_managed_prefix_list" "cloudfront_origin_facing" {

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -11,23 +11,13 @@ resource "aws_security_group" "alb" {
   }
 }
 
-resource "aws_security_group_rule" "alb_ingress_https" {
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "HTTPS from internet"
-  security_group_id = aws_security_group.alb.id
-}
-
 resource "aws_security_group_rule" "alb_ingress_http" {
   type              = "ingress"
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "HTTP from internet (redirects to HTTPS)"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.cloudfront_origin_facing.id]
+  description       = "HTTP from CloudFront origin-facing servers"
   security_group_id = aws_security_group.alb.id
 }
 
@@ -64,14 +54,14 @@ resource "aws_security_group_rule" "api_ingress_from_alb" {
   security_group_id        = aws_security_group.api.id
 }
 
-resource "aws_security_group_rule" "api_egress_https" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "AWS services (SQS, CloudWatch, SSM)"
-  security_group_id = aws_security_group.api.id
+resource "aws_security_group_rule" "api_egress_to_vpc_endpoints" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpc_endpoints.id
+  description              = "AWS services through VPC endpoints"
+  security_group_id        = aws_security_group.api.id
 }
 
 resource "aws_security_group_rule" "api_egress_to_rds" {
@@ -142,16 +132,6 @@ resource "aws_security_group_rule" "rds_ingress_from_api" {
   security_group_id        = aws_security_group.rds.id
 }
 
-resource "aws_security_group_rule" "rds_ingress_from_worker" {
-  type                     = "ingress"
-  from_port                = var.db_port
-  to_port                  = var.db_port
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.worker.id
-  description              = "From Worker services"
-  security_group_id        = aws_security_group.rds.id
-}
-
 # ============================================
 # VPC Endpoints Security Group
 # ============================================
@@ -160,15 +140,21 @@ resource "aws_security_group" "vpc_endpoints" {
   description = "GuardBench VPC Endpoints - allow HTTPS from private subnets"
   vpc_id      = aws_vpc.main.id
 
-  ingress {
-    description     = "HTTPS from API and Worker services"
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = [aws_security_group.api.id, aws_security_group.worker.id]
-  }
-
   tags = {
     Name = "${var.project}-${var.environment}-vpce-sg"
   }
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_ingress_from_api" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.api.id
+  description              = "HTTPS from the combined app service"
+  security_group_id        = aws_security_group.vpc_endpoints.id
+}
+
+data "aws_ec2_managed_prefix_list" "cloudfront_origin_facing" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
 }

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,0 +1,35 @@
+locals {
+  queue_names = toset([
+    "gb-run-resolve",
+    "gb-workitems",
+    "gb-run-finalize",
+  ])
+}
+
+resource "aws_sqs_queue" "dead_letter" {
+  for_each = local.queue_names
+
+  name                      = "${var.project}-${var.environment}-${each.value}-dlq"
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name = "${var.project}-${var.environment}-${each.value}-dlq"
+  }
+}
+
+resource "aws_sqs_queue" "source" {
+  for_each = local.queue_names
+
+  name                       = "${var.project}-${var.environment}-${each.value}"
+  visibility_timeout_seconds = 30
+  receive_wait_time_seconds  = 20
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dead_letter[each.key].arn
+    maxReceiveCount     = 5
+  })
+
+  tags = {
+    Name = "${var.project}-${var.environment}-${each.value}"
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -10,3 +10,6 @@ vpc_cidr             = "10.1.0.0/16"
 # availability_zones = ["ap-northeast-2a", "ap-northeast-2c"]  # 기본값 사용
 public_subnet_cidrs  = ["10.1.1.0/24", "10.1.2.0/24"]
 private_subnet_cidrs = ["10.1.10.0/24", "10.1.20.0/24"]
+
+# 검증된 backend commit SHA로 바꿔 사용합니다. latest tag는 허용하지 않습니다.
+app_image_tag = "0123456789abcdef0123456789abcdef01234567"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "aws_region" {
 variable "vpc_cidr" {
   description = "VPC CIDR block"
   type        = string
-  default     = "10.0.0.0/16"
+  default     = "10.1.0.0/16"
 }
 
 variable "availability_zones" {
@@ -34,13 +34,13 @@ variable "availability_zones" {
 variable "public_subnet_cidrs" {
   description = "CIDR blocks for public subnets (ALB)"
   type        = list(string)
-  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+  default     = ["10.1.1.0/24", "10.1.2.0/24"]
 }
 
 variable "private_subnet_cidrs" {
   description = "CIDR blocks for private subnets (ECS, RDS, VPC Endpoints)"
   type        = list(string)
-  default     = ["10.0.10.0/24", "10.0.20.0/24"]
+  default     = ["10.1.10.0/24", "10.1.20.0/24"]
 }
 
 # ============================================
@@ -64,28 +64,27 @@ variable "api_memory" {
   default     = 1024
 }
 
-variable "api_desired_count" {
-  description = "Number of API tasks"
-  type        = number
-  default     = 2
-}
-
-variable "worker_cpu" {
-  description = "CPU units for worker tasks (orchestrator/executor)"
-  type        = number
-  default     = 512
-}
-
-variable "worker_memory" {
-  description = "Memory (MiB) for worker tasks"
-  type        = number
-  default     = 1024
-}
-
-variable "worker_desired_count" {
-  description = "Number of worker tasks (orchestrator/executor each)"
+variable "app_desired_count" {
+  description = "Number of combined application tasks"
   type        = number
   default     = 1
+}
+
+variable "app_image_tag" {
+  description = "Immutable ECR tag for the verified backend commit"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{7,64}$", var.app_image_tag))
+    error_message = "app_image_tag must be a verified Git commit SHA."
+  }
+}
+
+variable "alarm_email" {
+  description = "Optional email address that confirms the dev operations SNS subscription"
+  type        = string
+  default     = null
+  nullable    = true
 }
 
 variable "db_port" {

--- a/terraform/vpc-endpoints.tf
+++ b/terraform/vpc-endpoints.tf
@@ -131,4 +131,18 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
+# RDS managed master secret을 ECS Task Definition에 주입할 때 필요하다.
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-secretsmanager"
+  }
+}
+
 # S3 Gateway 엔드포인트 라우트 테이블 연결은 vpc.tf에서 처리됩니다.


### PR DESCRIPTION
## Summary
- 기존 CloudFront/ALB/SG를 현재 backend 실행 계약에 맞추고 CloudFront origin 접근을 제한합니다.
- GuardBench 전용 RDS, Secrets Manager VPC Endpoint, SQS source/DLQ 3쌍을 추가합니다.
- API·Outbox Publisher·세 consumer를 단일 immutable-image ECS App Service로 배포하고 최소 권한 IAM·CloudWatch/SNS 관측성을 구성합니다.

## Verification
- `terraform fmt -check`
- `terraform validate`
- `terraform plan -var=app_image_tag=73022a63dc4fb2c673ef3662e542de2b97cb2a6a`
- Plan: 33 create, 3 in-place update, 4 destroy.
  - replacement 1건과 destroy 3건은 기존의 과도한 Security Group rule을 CloudFront prefix list·VPC Endpoint·단일 App Service 규칙으로 교체/제거하는 의도된 변경입니다.
  - VPC Endpoint SG도 in-place update로 API SG만 허용하도록 바꿔 Worker SG의 443 접근을 제거합니다.
  - VPC, subnet, S3, CloudFront Distribution, ALB, Target Group 자체의 삭제·교체는 없습니다.

## Apply checklist
- 검증된 backend commit SHA 이미지를 ECR에 push한 뒤 `app_image_tag`으로 전달합니다.
- Security Group rule 변경으로 CloudFront-origin ALB 접근 및 ECS-to-Endpoint/RDS 경로가 유지되는지 확인합니다.
- `alarm_email`을 설정했다면 SNS confirmation을 수신자가 승인합니다.

Closes #2