### PR TITLE
fix(infra): allow ECS image layers through S3 Gateway

### DIFF
--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -64,6 +64,19 @@ resource "aws_security_group_rule" "api_egress_to_vpc_endpoints" {
   security_group_id        = aws_security_group.api.id
 }
 
+# ECR image layer downloads use the S3 Gateway endpoint rather than an
+# interface endpoint ENI. Restrict the task egress to the endpoint's managed
+# S3 prefix list; no internet or NAT route is required.
+resource "aws_security_group_rule" "api_egress_to_s3_gateway" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [aws_vpc_endpoint.s3.prefix_list_id]
+  description       = "ECR image layers through S3 Gateway endpoint"
+  security_group_id = aws_security_group.api.id
+}
+
 resource "aws_security_group_rule" "api_egress_to_rds" {
   type                     = "egress"
   from_port                = var.db_port


### PR DESCRIPTION
## Summary
- Allow the combined ECS app task to make HTTPS egress to the S3 Gateway Endpoint managed prefix list.
- Keep Interface Endpoint, RDS, and internet/NAT access boundaries unchanged.

## Why
ECR image metadata uses the ECR Interface Endpoints, but image layers are downloaded through S3. The former configuration omitted the S3 Gateway Endpoint prefix-list egress rule, causing `CannotPullContainerError` timeouts.

## Verification
- `terraform fmt -check`
- `terraform validate`
- `terraform plan`: `No changes` after the verified one-rule apply
- ECS deployment completed with desired/running `1/1`; Target Group healthy

Closes #4