### PR TITLE
feat(iam): frontend GitHub OIDC 배포 Role 구성

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,3 +27,28 @@ terraform plan -out=tfplan
 계획에서 기존 네트워크, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다.
 
 ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
+
+## 프론트엔드 GitHub Actions OIDC 배포
+
+계정에 `token.actions.githubusercontent.com` OIDC provider가 이미 있는지 먼저 확인한다.
+
+```bash
+aws iam list-open-id-connect-providers
+aws iam get-open-id-connect-provider \
+  --open-id-connect-provider-arn arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com
+```
+
+기존 provider가 있으면 `github_oidc_provider_arn`에 ARN을 설정한다. 없으면 Terraform이 provider를 생성한다. 교육용 계정에서 `iam:CreateOpenIDConnectProvider`가 거부될 경우 계정 관리자에게 기존 provider 생성 또는 ARN 제공을 요청하고 이 변수로 재사용한다. frontend deploy role의 trust는 audience `sts.amazonaws.com`과 `GuardBench/guardbench-frontend`의 `refs/heads/main` subject로만 제한된다. `workflow_dispatch`도 main ref에서 실행하면 같은 subject 조건을 사용한다.
+
+Role은 dev frontend bucket의 조회 및 object 조회·생성·삭제와 해당 CloudFront distribution의 invalidation만 허용한다. IAM 관리, backend 배포, Terraform 권한은 포함하지 않는다.
+
+apply와 plan 검토 후 frontend repository variable을 등록한다. 이 변경들은 각각 별도 승인을 받은 뒤 실행한다.
+
+```bash
+terraform output -raw frontend_github_actions_role_arn
+gh variable set AWS_DEPLOY_ROLE_ARN --repo GuardBench/guardbench-frontend --body "ROLE_ARN"
+```
+
+frontend workflow는 `permissions: id-token: write`와 `aws-actions/configure-aws-credentials`의 `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}`를 사용한다. OIDC 배포 성공을 확인하기 전에는 기존 Access Key secrets를 제거하지 않는다.
+
+전환 완료 후 repository의 `AWS_ACCESS_KEY_ID`와 `AWS_SECRET_ACCESS_KEY` secrets를 삭제한다. 롤백이 필요하면 workflow를 직전 revision으로 되돌리고 보관 중인 기존 secrets로 재실행한다. 보안 사고가 원인이면 기존 키를 재사용하지 말고 새 키를 발급한다. Role 자체 롤백은 frontend workflow가 더 이상 사용하지 않음을 확인한 뒤 Terraform에서 제거한다.

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -1,0 +1,87 @@
+# GitHub Actions OIDC provider is account-wide. Reuse an existing provider by
+# setting github_oidc_provider_arn; otherwise this stack creates it.
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  count = var.github_oidc_provider_arn == null ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = {
+    Name = "github-actions-oidc"
+  }
+}
+
+locals {
+  github_oidc_provider_arn = var.github_oidc_provider_arn != null ? var.github_oidc_provider_arn : aws_iam_openid_connect_provider.github_actions[0].arn
+}
+
+data "aws_iam_policy_document" "frontend_github_actions_assume_role" {
+  statement {
+    sid     = "GitHubActionsMainBranch"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:GuardBench/guardbench-frontend:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "frontend_github_actions_deploy" {
+  name               = "${var.project}-${var.environment}-frontend-github-deploy"
+  description        = "Deploy GuardBench dev frontend from GitHub Actions main branch"
+  assume_role_policy = data.aws_iam_policy_document.frontend_github_actions_assume_role.json
+
+  max_session_duration = 3600
+
+  tags = {
+    Name = "${var.project}-${var.environment}-frontend-github-deploy"
+  }
+}
+
+data "aws_iam_policy_document" "frontend_github_actions_deploy" {
+  statement {
+    sid = "ReadFrontendBucket"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+    resources = [aws_s3_bucket.frontend.arn]
+  }
+
+  statement {
+    sid = "SyncFrontendObjects"
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+  }
+
+  statement {
+    sid       = "InvalidateFrontendDistribution"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.frontend.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "frontend_github_actions_deploy" {
+  name   = "${var.project}-${var.environment}-frontend-deploy"
+  role   = aws_iam_role.frontend_github_actions_deploy.id
+  policy = data.aws_iam_policy_document.frontend_github_actions_deploy.json
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -44,6 +44,11 @@ output "s3_frontend_bucket_arn" {
   value       = aws_s3_bucket.frontend.arn
 }
 
+output "frontend_github_actions_role_arn" {
+  description = "Role ARN used by guardbench-frontend GitHub Actions via OIDC"
+  value       = aws_iam_role.frontend_github_actions_deploy.arn
+}
+
 # ============================================
 # ALB Outputs
 # ============================================

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -5,6 +5,9 @@ project     = "guardbench"
 environment = "dev"
 aws_region  = "ap-northeast-2"
 
+# 계정에 GitHub Actions OIDC provider가 이미 있다면 ARN을 설정해 중복 생성을 피합니다.
+# github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+
 # VPC / 네트워크 (기존 VPC와 CIDR 충돌하지 않도록 설정)
 vpc_cidr             = "10.1.0.0/16"
 # availability_zones = ["ap-northeast-2a", "ap-northeast-2c"]  # 기본값 사용

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,21 @@ variable "aws_region" {
   default     = "ap-northeast-2"
 }
 
+variable "github_oidc_provider_arn" {
+  description = "Existing account-wide GitHub Actions OIDC provider ARN; null creates one"
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = var.github_oidc_provider_arn == null || can(regex(
+      "^arn:(aws|aws-us-gov|aws-cn):iam::[0-9]{12}:oidc-provider/token\\.actions\\.githubusercontent\\.com$",
+      var.github_oidc_provider_arn,
+    ))
+    error_message = "github_oidc_provider_arn must be the token.actions.githubusercontent.com provider ARN."
+  }
+}
+
 # ============================================
 # VPC / 네트워크 설정
 # ============================================


### PR DESCRIPTION
## 변경 사항
- GitHub Actions OIDC provider 생성 또는 기존 ARN 재사용
- guardbench-frontend main 브랜치 전용 deploy role 구성
- dev frontend S3 sync 및 CloudFront invalidation 최소 권한 적용
- Role ARN output과 Access Key 전환/rollback runbook 추가

## 검증
- terraform fmt -check
- terraform validate
- IAM target plan: 3 add, 0 change, 0 destroy
- AWS apply 및 trust/policy 검증 완료

Refs #6