### PR TITLE
fix(iam): custom GitHub OIDC subject 신뢰

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,7 +38,7 @@ aws iam get-open-id-connect-provider \
   --open-id-connect-provider-arn arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com
 ```
 
-기존 provider가 있으면 `github_oidc_provider_arn`에 ARN을 설정한다. 없으면 Terraform이 provider를 생성한다. 교육용 계정에서 `iam:CreateOpenIDConnectProvider`가 거부될 경우 계정 관리자에게 기존 provider 생성 또는 ARN 제공을 요청하고 이 변수로 재사용한다. frontend deploy role의 trust는 audience `sts.amazonaws.com`과 `GuardBench/guardbench-frontend`의 `refs/heads/main` subject로만 제한된다. `workflow_dispatch`도 main ref에서 실행하면 같은 subject 조건을 사용한다.
+기존 provider가 있으면 `github_oidc_provider_arn`에 ARN을 설정한다. 없으면 Terraform이 provider를 생성한다. 교육용 계정에서 `iam:CreateOpenIDConnectProvider`가 거부될 경우 계정 관리자에게 기존 provider 생성 또는 ARN 제공을 요청하고 이 변수로 재사용한다. frontend deploy role의 trust는 audience `sts.amazonaws.com`과 `GuardBench/guardbench-frontend`의 immutable organization/repository ID가 포함된 custom subject, `refs/heads/main`으로만 제한된다. `workflow_dispatch`도 main ref에서 실행하면 같은 subject 조건을 사용한다.
 
 Role은 dev frontend bucket의 조회 및 object 조회·생성·삭제와 해당 CloudFront distribution의 invalidation만 허용한다. IAM 관리, backend 배포, Terraform 권한은 포함하지 않는다.
 

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -36,7 +36,11 @@ data "aws_iam_policy_document" "frontend_github_actions_assume_role" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:GuardBench/guardbench-frontend:ref:refs/heads/main"]
+      # GuardBench customizes GitHub OIDC subjects with immutable organization
+      # and repository IDs. Keep the main ref suffix to restrict deployments.
+      values = [
+        "repo:GuardBench@316853045/guardbench-frontend@1346059955:ref:refs/heads/main",
+      ]
     }
   }
 }


### PR DESCRIPTION
GuardBench 조직의 custom OIDC subject 형식에 맞춰 immutable organization/repository ID와 main ref를 trust policy에 고정합니다.

실제 Actions claim으로 검증했으며 AWS Role trust 업데이트를 적용했습니다.

Refs #6