### PR TITLE
fix(cloudfront): API 오류를 보존하는 SPA fallback 적용

### DIFF
--- a/terraform/cloudfront-s3.tf
+++ b/terraform/cloudfront-s3.tf
@@ -68,6 +68,28 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
   signing_protocol                  = "sigv4"
 }
 
+# SPA 경로만 index.html로 재작성한다.
+# default cache behavior에만 연결되어 API 응답 상태와 본문은 변경하지 않는다.
+resource "aws_cloudfront_function" "spa_rewrite" {
+  name    = "${var.project}-${var.environment}-spa-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrite extensionless frontend routes to the SPA entry point"
+  publish = true
+  code    = <<-JS
+    function handler(event) {
+      var request = event.request;
+      var uri = request.uri;
+      var lastSegment = uri.substring(uri.lastIndexOf('/') + 1);
+
+      if (!uri.startsWith('/api/') && !lastSegment.includes('.')) {
+        request.uri = '/${var.spa_index_document}';
+      }
+
+      return request;
+    }
+  JS
+}
+
 # --- CloudFront Distribution ---
 resource "aws_cloudfront_distribution" "frontend" {
   enabled             = true
@@ -117,6 +139,11 @@ resource "aws_cloudfront_distribution" "frontend" {
     min_ttl     = 0
     default_ttl = 86400    # 1일
     max_ttl     = 31536000 # 1년
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.spa_rewrite.arn
+    }
   }
 
   # /api/* 경로는 백엔드 ALB로 프록시 (CORS 우회용)
@@ -130,21 +157,6 @@ resource "aws_cloudfront_distribution" "frontend" {
 
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id
-  }
-
-  # SPA 클라이언트 라우팅: 404 → index.html 반환
-  custom_error_response {
-    error_code            = 403
-    response_code         = 200
-    response_page_path    = "/${var.spa_error_document}"
-    error_caching_min_ttl = 10
-  }
-
-  custom_error_response {
-    error_code            = 404
-    response_code         = 200
-    response_page_path    = "/${var.spa_error_document}"
-    error_caching_min_ttl = 10
   }
 
   # CloudFront 기본 인증서 (*.cloudfront.net)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -113,9 +113,3 @@ variable "spa_index_document" {
   type        = string
   default     = "index.html"
 }
-
-variable "spa_error_document" {
-  description = "Error document for SPA fallback (client-side routing)"
-  type        = string
-  default     = "index.html"
-}


### PR DESCRIPTION
## 변경 사항
- default cache behavior에 viewer-request CloudFront Function을 연결했습니다.
- 확장자가 없는 프론트 경로만 `index.html`로 rewrite합니다.
- `/api/*`는 Function 코드에서도 rewrite 대상에서 제외했습니다.
- distribution 전체에 적용되던 403/404 custom error response를 제거했습니다.
- 더 이상 쓰지 않는 `spa_error_document` 변수를 제거했습니다.

## 배경
기존 custom error response는 `/api/*` ALB 응답에도 적용되어 Backend의 403/404 JSON을 `200 + index.html`로 바꿀 수 있었습니다. 이 경우 프론트 API client가 응답을 `INVALID_RESPONSE`로 해석해 원래 오류 code와 status를 잃습니다.

## 검증
- `terraform fmt -check` 통과
- `terraform validate` 통과
- `terraform plan -input=false -lock=false` 시도
  - 현재 자격 증명이 `s3://guardbench-terraform-state/infra/terraform.tfstate` HeadObject에 403을 받아 plan은 미완료

## 배포 후 확인
- 존재하지 않는 API가 원래 status와 JSON을 유지하는지 확인
- SPA deep link가 `200 + index.html`인지 확인
- 누락 정적 자산이 index.html로 위장되지 않는지 확인
- 필요하면 `/api/*`, `/index.html` cache invalidation 수행

Closes #10