### PR TITLE
feat(iam): add backend GitHub Actions OIDC deploy role

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,13 +28,13 @@ terraform plan -out=tfplan
 
 Bootstrap 시 ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. 이후 Backend application 배포는 `app_image_tag` 변경이 아니라 Backend GitHub Actions로 수행한다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
 
-Task Definition infrastructure configuration을 변경한 경우에는 다음 순서를 따른다.
+Task Definition infrastructure configuration을 변경한 경우에는 Backend issue #142가 적용된 뒤 다음 순서를 따른다.
 
 ```text
 terraform apply
 → 새로운 base Task Definition revision 등록
 → Backend GitHub Actions deploy
-→ family의 latest ACTIVE revision을 base로 image만 교체
+→ Backend #142 workflow가 family의 latest ACTIVE revision을 base로 image만 교체
 → 새로운 deployment revision 등록
 → ECS Service update
 ```
@@ -80,10 +80,11 @@ gh variable set ECR_REPOSITORY --repo GuardBench/guardbench-backend --env dev --
 gh variable set ECS_CLUSTER --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-cluster"
 gh variable set ECS_SERVICE --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-app"
 gh variable set ECS_CONTAINER_NAME --repo GuardBench/guardbench-backend --env dev --body "app"
+# Backend issue #142 적용 후 workflow에서 사용하는 변수
 gh variable set ECS_TASK_DEFINITION_FAMILY --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-app"
 ```
 
-backend workflow는 `permissions: id-token: write`, `environment: dev`, `configure-aws-credentials`의 `role-to-assume`, 그리고 다음 리소스 변수를 사용한다.
+Backend issue #142 적용 후 backend workflow는 `permissions: id-token: write`, `environment: dev`, `configure-aws-credentials`의 `role-to-assume`, 그리고 다음 리소스 변수를 사용한다. 현재 workflow가 이 계약을 적용하기 전에는 `ECS_TASK_DEFINITION_FAMILY`를 설정해도 Service의 current revision base 문제가 해결되지 않는다.
 
 - `AWS_REGION`: `ap-northeast-2`
 - `ECR_REPOSITORY`: `guardbench-dev`
@@ -96,4 +97,4 @@ backend workflow는 `permissions: id-token: write`, `environment: dev`, `configu
 
 ### ECS task definition 소유권
 
-최초 ECS Service와 baseline task definition은 Terraform이 생성한다. 이후 application task definition revision과 Service의 `task_definition` 변경은 Backend GitHub Actions가 소유한다. `aws_ecs_service.app`에는 `task_definition`에 대한 `ignore_changes`가 설정되어 있어 Terraform이 CI가 배포한 revision을 이전 revision으로 되돌리지 않는다. Backend workflow는 Service의 current revision이 아닌 family의 latest ACTIVE revision을 base로 사용해야 하며, Terraform으로 container definition 자체를 변경한 경우에는 `terraform apply` 후 Backend 배포 workflow를 실행해야 최신 설정이 유지된다. 일반 Backend 배포를 위해 `app_image_tag`를 변경하지 않는다.
+최초 ECS Service와 baseline task definition은 Terraform이 생성한다. 이후 application task definition revision과 Service의 `task_definition` 변경은 Backend GitHub Actions가 소유한다. `aws_ecs_service.app`에는 `task_definition`에 대한 `ignore_changes`가 설정되어 있어 Terraform이 CI가 배포한 revision을 이전 revision으로 되돌리지 않는다. Backend issue #142 적용 후 workflow는 Service의 current revision이 아닌 family의 latest ACTIVE revision을 base로 사용해야 하며, Terraform으로 container definition 자체를 변경한 경우에는 `terraform apply` 후 Backend 배포 workflow를 실행해야 최신 설정이 유지된다. #142 적용 전에는 현재 workflow가 Service current revision을 base로 사용하므로 이 runbook의 latest ACTIVE 보존 계약이 아직 유효하지 않다. 일반 Backend 배포를 위해 `app_image_tag`를 변경하지 않는다.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,7 +5,7 @@
 ## 준비
 
 1. Terraform 1.10 이상과 `ap-northeast-2` AWS credential을 준비한다.
-2. `terraform.tfvars.example`을 복사하여 `app_image_tag`에 `clean check bootBuildImage`를 통과한 backend commit SHA를 넣는다.
+2. `terraform.tfvars.example`을 복사하여 bootstrap에 사용할 `app_image_tag`에 `clean check bootBuildImage`를 통과한 backend commit SHA를 넣는다. 이 값은 최초 Task Definition 생성을 위한 값이며 일반 Backend 배포용이 아니다.
 3. `terraform init -input=false` 후 `terraform state list`를 실행한다.
 4. state에 없는 기존 리소스만 해당 Terraform address로 import한다. import 대상과 ID는 적용 직전에 AWS 조회 결과로 확정한다.
 
@@ -24,9 +24,20 @@ terraform validate
 terraform plan -out=tfplan
 ```
 
-계획에서 기존 네트워크, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다.
+계획에서 기존 네트워크, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다. Terraform apply 자체는 Backend application 재배포를 의미하지 않는다.
 
-ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
+Bootstrap 시 ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. 이후 Backend application 배포는 `app_image_tag` 변경이 아니라 Backend GitHub Actions로 수행한다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
+
+Task Definition infrastructure configuration을 변경한 경우에는 다음 순서를 따른다.
+
+```text
+terraform apply
+→ 새로운 base Task Definition revision 등록
+→ Backend GitHub Actions deploy
+→ family의 latest ACTIVE revision을 base로 image만 교체
+→ 새로운 deployment revision 등록
+→ ECS Service update
+```
 
 ## 프론트엔드 GitHub Actions OIDC 배포
 
@@ -69,6 +80,7 @@ gh variable set ECR_REPOSITORY --repo GuardBench/guardbench-backend --env dev --
 gh variable set ECS_CLUSTER --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-cluster"
 gh variable set ECS_SERVICE --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-app"
 gh variable set ECS_CONTAINER_NAME --repo GuardBench/guardbench-backend --env dev --body "app"
+gh variable set ECS_TASK_DEFINITION_FAMILY --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-app"
 ```
 
 backend workflow는 `permissions: id-token: write`, `environment: dev`, `configure-aws-credentials`의 `role-to-assume`, 그리고 다음 리소스 변수를 사용한다.
@@ -78,9 +90,10 @@ backend workflow는 `permissions: id-token: write`, `environment: dev`, `configu
 - `ECS_CLUSTER`: `guardbench-dev-cluster`
 - `ECS_SERVICE`: `guardbench-dev-app`
 - `ECS_CONTAINER_NAME`: `app`
+- `ECS_TASK_DEFINITION_FAMILY`: `guardbench-dev-app`
 
 이 Role은 지정된 ECR repository push, `guardbench-dev-app` task definition family 등록, 해당 ECS service 조회·갱신, ECS execution/app task role에 대한 제한된 `iam:PassRole`만 허용한다. Task definition tags를 workflow에서 전달하지 않으므로 `ecs:TagResource`는 부여하지 않는다.
 
 ### ECS task definition 소유권
 
-최초 ECS Service와 baseline task definition은 Terraform이 생성한다. 이후 application task definition revision과 Service의 `task_definition` 변경은 Backend GitHub Actions가 소유한다. `aws_ecs_service.app`에는 `task_definition`에 대한 `ignore_changes`가 설정되어 있어 Terraform이 CI가 배포한 revision을 이전 revision으로 되돌리지 않는다. 따라서 Terraform으로 container definition 자체를 변경한 경우에는 Backend 배포 workflow를 통해 새 revision을 배포해야 한다.
+최초 ECS Service와 baseline task definition은 Terraform이 생성한다. 이후 application task definition revision과 Service의 `task_definition` 변경은 Backend GitHub Actions가 소유한다. `aws_ecs_service.app`에는 `task_definition`에 대한 `ignore_changes`가 설정되어 있어 Terraform이 CI가 배포한 revision을 이전 revision으로 되돌리지 않는다. Backend workflow는 Service의 current revision이 아닌 family의 latest ACTIVE revision을 base로 사용해야 하며, Terraform으로 container definition 자체를 변경한 경우에는 `terraform apply` 후 Backend 배포 workflow를 실행해야 최신 설정이 유지된다. 일반 Backend 배포를 위해 `app_image_tag`를 변경하지 않는다.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -80,3 +80,7 @@ backend workflow는 `permissions: id-token: write`, `environment: dev`, `configu
 - `ECS_CONTAINER_NAME`: `app`
 
 이 Role은 지정된 ECR repository push, `guardbench-dev-app` task definition family 등록, 해당 ECS service 조회·갱신, ECS execution/app task role에 대한 제한된 `iam:PassRole`만 허용한다. Task definition tags를 workflow에서 전달하지 않으므로 `ecs:TagResource`는 부여하지 않는다.
+
+### ECS task definition 소유권
+
+최초 ECS Service와 baseline task definition은 Terraform이 생성한다. 이후 application task definition revision과 Service의 `task_definition` 변경은 Backend GitHub Actions가 소유한다. `aws_ecs_service.app`에는 `task_definition`에 대한 `ignore_changes`가 설정되어 있어 Terraform이 CI가 배포한 revision을 이전 revision으로 되돌리지 않는다. 따라서 Terraform으로 container definition 자체를 변경한 경우에는 Backend 배포 workflow를 통해 새 revision을 배포해야 한다.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -52,3 +52,31 @@ gh variable set AWS_DEPLOY_ROLE_ARN --repo GuardBench/guardbench-frontend --body
 frontend workflow는 `permissions: id-token: write`와 `aws-actions/configure-aws-credentials`의 `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}`를 사용한다. OIDC 배포 성공을 확인하기 전에는 기존 Access Key secrets를 제거하지 않는다.
 
 전환 완료 후 repository의 `AWS_ACCESS_KEY_ID`와 `AWS_SECRET_ACCESS_KEY` secrets를 삭제한다. 롤백이 필요하면 workflow를 직전 revision으로 되돌리고 보관 중인 기존 secrets로 재실행한다. 보안 사고가 원인이면 기존 키를 재사용하지 말고 새 키를 발급한다. Role 자체 롤백은 frontend workflow가 더 이상 사용하지 않음을 확인한 뒤 Terraform에서 제거한다.
+
+## 백엔드 GitHub Actions OIDC 배포
+
+`backend_github_actions_role_arn`은 `GuardBench/guardbench-backend`의 `dev` Environment에서만 사용할 수 있다. Trust policy는 immutable organization/repository ID와 `environment:dev` subject, audience `sts.amazonaws.com`으로 제한된다. Environment subject에는 branch가 들어가지 않으므로 GitHub repository의 `dev` Environment에서 Deployment branches and tags를 `dev` 브랜치로 제한한다.
+
+```bash
+terraform output -raw backend_github_actions_role_arn
+gh variable set AWS_DEPLOY_ROLE_ARN \
+  --repo GuardBench/guardbench-backend \
+  --env dev \
+  --body "ROLE_ARN"
+
+gh variable set AWS_REGION --repo GuardBench/guardbench-backend --env dev --body "ap-northeast-2"
+gh variable set ECR_REPOSITORY --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev"
+gh variable set ECS_CLUSTER --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-cluster"
+gh variable set ECS_SERVICE --repo GuardBench/guardbench-backend --env dev --body "guardbench-dev-app"
+gh variable set ECS_CONTAINER_NAME --repo GuardBench/guardbench-backend --env dev --body "app"
+```
+
+backend workflow는 `permissions: id-token: write`, `environment: dev`, `configure-aws-credentials`의 `role-to-assume`, 그리고 다음 리소스 변수를 사용한다.
+
+- `AWS_REGION`: `ap-northeast-2`
+- `ECR_REPOSITORY`: `guardbench-dev`
+- `ECS_CLUSTER`: `guardbench-dev-cluster`
+- `ECS_SERVICE`: `guardbench-dev-app`
+- `ECS_CONTAINER_NAME`: `app`
+
+이 Role은 지정된 ECR repository push, `guardbench-dev-app` task definition family 등록, 해당 ECS service 조회·갱신, ECS execution/app task role에 대한 제한된 `iam:PassRole`만 허용한다. Task definition tags를 workflow에서 전달하지 않으므로 `ecs:TagResource`는 부여하지 않는다.

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -152,6 +152,13 @@ resource "aws_ecs_service" "app" {
   desired_count   = var.app_desired_count
   launch_type     = "FARGATE"
 
+  # GitHub Actions owns application task-definition revisions after the
+  # initial service creation. Terraform continues to own the service shape
+  # but must not roll the service back to its baseline revision.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
   network_configuration {
     subnets          = aws_subnet.private[*].id
     security_groups  = [aws_security_group.api.id]

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -159,10 +159,11 @@ data "aws_iam_policy_document" "backend_github_actions_deploy" {
   }
 
   statement {
-    sid       = "DescribeAppTaskDefinition"
-    effect    = "Allow"
-    actions   = ["ecs:DescribeTaskDefinition"]
-    resources = [local.backend_task_definition_family_arn]
+    sid     = "DescribeTaskDefinition"
+    effect  = "Allow"
+    actions = ["ecs:DescribeTaskDefinition"]
+    # ECS does not support resource-level permissions for this action.
+    resources = ["*"]
   }
 
   statement {

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -14,7 +14,12 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
 
 locals {
   github_oidc_provider_arn = var.github_oidc_provider_arn != null ? var.github_oidc_provider_arn : aws_iam_openid_connect_provider.github_actions[0].arn
+
+  backend_task_definition_family_arn = "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${var.project}-${var.environment}-app:*"
+  backend_ecs_service_arn            = "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.main.name}/${aws_ecs_service.app.name}"
 }
+
+data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "frontend_github_actions_assume_role" {
   statement {
@@ -88,4 +93,121 @@ resource "aws_iam_role_policy" "frontend_github_actions_deploy" {
   name   = "${var.project}-${var.environment}-frontend-deploy"
   role   = aws_iam_role.frontend_github_actions_deploy.id
   policy = data.aws_iam_policy_document.frontend_github_actions_deploy.json
+}
+
+data "aws_iam_policy_document" "backend_github_actions_assume_role" {
+  statement {
+    sid     = "GitHubActionsDevEnvironment"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      # Environment subjects do not contain a branch. Restrict the GitHub
+      # dev environment's deployment branches/tags in repository settings.
+      values = [
+        "repo:GuardBench@316853045/guardbench-backend@1333885107:environment:dev",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "backend_github_actions_deploy" {
+  name               = "${var.project}-${var.environment}-backend-github-deploy"
+  description        = "Deploy GuardBench dev backend from GitHub Actions via OIDC"
+  assume_role_policy = data.aws_iam_policy_document.backend_github_actions_assume_role.json
+
+  max_session_duration = 3600
+
+  tags = {
+    Name = "${var.project}-${var.environment}-backend-github-deploy"
+  }
+}
+
+data "aws_iam_policy_document" "backend_github_actions_deploy" {
+  statement {
+    sid       = "EcrAuthorization"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "PushBackendImage"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [aws_ecr_repository.app.arn]
+  }
+
+  statement {
+    sid       = "DescribeAppTaskDefinition"
+    effect    = "Allow"
+    actions   = ["ecs:DescribeTaskDefinition"]
+    resources = [local.backend_task_definition_family_arn]
+  }
+
+  statement {
+    sid       = "RegisterAppTaskDefinition"
+    effect    = "Allow"
+    actions   = ["ecs:RegisterTaskDefinition"]
+    resources = [local.backend_task_definition_family_arn]
+  }
+
+  statement {
+    sid       = "DescribeAppService"
+    effect    = "Allow"
+    actions   = ["ecs:DescribeServices"]
+    resources = [local.backend_ecs_service_arn]
+  }
+
+  statement {
+    sid       = "UpdateAppService"
+    effect    = "Allow"
+    actions   = ["ecs:UpdateService"]
+    resources = [local.backend_ecs_service_arn]
+
+    condition {
+      test     = "ArnLike"
+      variable = "ecs:task-definition"
+      values   = [local.backend_task_definition_family_arn]
+    }
+  }
+
+  statement {
+    sid       = "PassEcsTaskRoles"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.ecs_task_execution.arn, aws_iam_role.app_task.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "backend_github_actions_deploy" {
+  name   = "${var.project}-${var.environment}-backend-deploy"
+  role   = aws_iam_role.backend_github_actions_deploy.id
+  policy = data.aws_iam_policy_document.backend_github_actions_deploy.json
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -49,6 +49,11 @@ output "frontend_github_actions_role_arn" {
   value       = aws_iam_role.frontend_github_actions_deploy.arn
 }
 
+output "backend_github_actions_role_arn" {
+  description = "Role ARN used by guardbench-backend GitHub Actions via OIDC"
+  value       = aws_iam_role.backend_github_actions_deploy.arn
+}
+
 # ============================================
 # ALB Outputs
 # ============================================


### PR DESCRIPTION
## Summary

- add a backend GitHub Actions OIDC deploy role with immutable repository/environment trust
- restrict ECR push, ECS task definition/service operations, and iam:PassRole to required resources
- delegate post-bootstrap ECS task-definition revisions to Backend GitHub Actions so Terraform cannot roll CI deployments back
- document `app_image_tag` as bootstrap-only and the `terraform apply → Backend deploy` order
- preserve Terraform ownership of Task Definition infrastructure configuration

## Ownership decision

- Terraform owns ECS infrastructure, Task Definition family and infrastructure configuration, and the initial bootstrap revision.
- Backend GitHub Actions owns the application image and deployment revision.
- `aws_ecs_service.app.task_definition` uses `lifecycle.ignore_changes` so Terraform does not roll the Service back to its baseline revision.
- Backend workflow latest ACTIVE base selection is intentionally not changed in this IaC PR; it is tracked in [Backend issue #142](https://github.com/GuardBench/guardbench-backend/issues/142).

## Review fixes

- `ecs:DescribeTaskDefinition` now uses `Resource = "*"`, because ECS does not support resource-level permissions for this action.
- `ecs:RegisterTaskDefinition` remains restricted to `guardbench-dev-app:*`.
- README now explicitly states that the latest ACTIVE base workflow contract applies only after Backend issue #142; configuring `ECS_TASK_DEFINITION_FAMILY` before #142 does not change the current workflow behavior.
- Issue #9 was not modified.

## Validation completed

- Terraform `fmt -check`
- Terraform `validate`
- IAM Access Analyzer `ValidatePolicy`: no findings
- AWS MCP IAM simulation after the fix:
  - `ecs:DescribeTaskDefinition` with `Resource="*"`: allowed
  - `ecs:RegisterTaskDefinition` for `guardbench-dev-app:11`: allowed
  - `ecs:RegisterTaskDefinition` for `other-app:11`: implicit deny
- AWS MCP documentation confirms that describing a task-definition family returns the latest ACTIVE revision.
- Scenario A/B ownership behavior verified statically: Terraform creates the baseline revision and ignores external Service revision changes; Backend #142 must consume the latest ACTIVE family revision.

## Remaining manual integration verification

The following require Backend issue #142 and a configured dev environment, so they are not claimed as completed here:

- real GitHub `dev` Environment OIDC AssumeRole
- latest ACTIVE family revision base selection and preservation of Terraform configuration
- allowed/denied ECR, ECS Service, Task Definition family, and PassRole scenarios
- post-deploy `terraform plan` against the live environment
- deployment branch restriction confirmation and long-term-key-free Backend deployment

At the latest check, the GitHub `dev` Environment had no deployment branch policy or variables configured, and the live AWS ECR/ECS resources required drift remediation. Issue #15 remains open until the backend workflow and real integration checks are complete.

Related to #15