### PR TITLE
feat(infra): add isolated performance RDS target

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,14 @@ terraform plan -out=tfplan
 
 계획에서 기존 네트워크, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다.
 
+## Performance RDS 운영 전제
+
+성능 테스트용 RDS는 dev RDS와 별도로 생성되며, private subnet에 위치하고 shared dev ECS API security group에서만 PostgreSQL 접근을 허용한다. ECS와 SQS/DLQ는 dev 환경과 공유한다. 따라서 성능 측정 중에는 다른 dev workload가 없어야 하며, 실행 전 Performance Runner가 기존 TestRun과 Source Queue/DLQ 상태를 검증해야 한다.
+
+기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 plan/apply하여 ECS task definition의 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하게 한다. Performance RDS의 instance class와 storage 변수는 적용 전에 성능 계획에 따라 설정한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다.
+
+task definition revision을 외부 배포 workflow가 갱신하는 경우에는 전체 apply 전 `terraform plan`에서 `aws_ecs_service.app`이 현재 정상 revision을 이전 revision으로 바꾸지 않는지 반드시 확인한다.
+
 ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
 
 ## 프론트엔드 GitHub Actions OIDC 배포

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -43,7 +43,7 @@ terraform apply
 
 성능 테스트용 RDS는 dev RDS와 별도로 생성되며, private subnet에 위치하고 shared dev ECS API security group에서만 PostgreSQL 접근을 허용한다. ECS와 SQS/DLQ는 dev 환경과 공유한다. 따라서 성능 측정 중에는 다른 dev workload가 없어야 하며, 실행 전 Performance Runner가 기존 TestRun과 Source Queue/DLQ 상태를 검증해야 한다.
 
-기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class와 storage 변수는 적용 전에 성능 계획에 따라 설정한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다.
+기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. shared ECS task execution role에는 Dev와 Performance RDS의 두 master secret만 허용해, 전환 중 기존 revision 재시작 또는 circuit breaker rollback도 안전하게 지원한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다.
 
 ## 프론트엔드 GitHub Actions OIDC 배포
 

--- a/terraform/cloudfront-s3.tf
+++ b/terraform/cloudfront-s3.tf
@@ -70,12 +70,10 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
 
 # SPA 경로만 index.html로 재작성한다.
 # default cache behavior에만 연결되어 API 응답 상태와 본문은 변경하지 않는다.
-resource "aws_cloudfront_function" "spa_rewrite" {
-  name    = "${var.project}-${var.environment}-spa-rewrite"
-  runtime = "cloudfront-js-2.0"
-  comment = "Rewrite extensionless frontend routes to the SPA entry point"
-  publish = true
-  code    = <<-JS
+locals {
+  # CloudFront stores function source with LF endings even when the repository
+  # is checked out with CRLF endings.
+  spa_rewrite_function_code = replace(<<-JS
     function handler(event) {
       var request = event.request;
       var uri = request.uri;
@@ -88,6 +86,15 @@ resource "aws_cloudfront_function" "spa_rewrite" {
       return request;
     }
   JS
+  , "\r\n", "\n")
+}
+
+resource "aws_cloudfront_function" "spa_rewrite" {
+  name    = "${var.project}-${var.environment}-spa-rewrite"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrite extensionless frontend routes to the SPA entry point"
+  publish = true
+  code    = local.spa_rewrite_function_code
 }
 
 # --- CloudFront Distribution ---

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,5 +1,15 @@
 data "aws_caller_identity" "current" {}
 
+locals {
+  selected_db = var.ecs_db_target == "performance" ? {
+    address           = aws_db_instance.performance.address
+    master_secret_arn = aws_db_instance.performance.master_user_secret[0].secret_arn
+    } : {
+    address           = aws_db_instance.app.address
+    master_secret_arn = aws_db_instance.app.master_user_secret[0].secret_arn
+  }
+}
+
 resource "aws_ecs_cluster" "main" {
   name = "${var.project}-${var.environment}-cluster"
 
@@ -45,7 +55,7 @@ resource "aws_iam_role_policy" "ecs_exec_secrets" {
     Statement = [{
       Effect   = "Allow"
       Action   = ["secretsmanager:GetSecretValue"]
-      Resource = aws_db_instance.app.master_user_secret[0].secret_arn
+      Resource = local.selected_db.master_secret_arn
     }]
   })
 }
@@ -119,7 +129,7 @@ resource "aws_ecs_task_definition" "app" {
     environment = [
       { name = "SERVER_PORT", value = tostring(var.api_container_port) },
       { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
-      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${aws_db_instance.app.address}:${var.db_port}/guardbench?sslmode=require" },
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${local.selected_db.address}:${var.db_port}/guardbench?sslmode=require" },
       { name = "AWS_REGION", value = var.aws_region },
       { name = "SQS_ENABLED", value = "true" },
       { name = "WORKER_ENABLED", value = "true" },
@@ -130,8 +140,8 @@ resource "aws_ecs_task_definition" "app" {
     ]
 
     secrets = [
-      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:username::" },
-      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:password::" },
+      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${local.selected_db.master_secret_arn}:username::" },
+      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${local.selected_db.master_secret_arn}:password::" },
     ]
 
     logConfiguration = {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -53,9 +53,15 @@ resource "aws_iam_role_policy" "ecs_exec_secrets" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["secretsmanager:GetSecretValue"]
-      Resource = local.selected_db.master_secret_arn
+      Effect = "Allow"
+      Action = ["secretsmanager:GetSecretValue"]
+      # The service and circuit breaker can still start a task from either
+      # Task Definition revision while a DB target switch is being deployed.
+      # Keep both intended RDS secrets available to the shared execution role.
+      Resource = [
+        aws_db_instance.app.master_user_secret[0].secret_arn,
+        aws_db_instance.performance.master_user_secret[0].secret_arn,
+      ]
     }]
   })
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -85,6 +85,16 @@ output "rds_endpoint" {
   value       = aws_db_instance.app.address
 }
 
+output "performance_rds_endpoint" {
+  description = "Private PostgreSQL endpoint for the performance-test RDS"
+  value       = aws_db_instance.performance.address
+}
+
+output "performance_rds_identifier" {
+  description = "Identifier for the performance-test RDS"
+  value       = aws_db_instance.performance.identifier
+}
+
 output "sqs_queue_urls" {
   description = "Source queue URLs injected into the app task definition"
   value       = { for name, queue in aws_sqs_queue.source : name => queue.url }
@@ -116,6 +126,11 @@ output "worker_security_group_id" {
 output "rds_security_group_id" {
   description = "RDS PostgreSQL security group ID"
   value       = aws_security_group.rds.id
+}
+
+output "performance_rds_security_group_id" {
+  description = "Security group ID for the performance-test RDS"
+  value       = aws_security_group.performance_rds.id
 }
 
 output "vpc_endpoints_security_group_id" {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -12,27 +12,58 @@ resource "aws_db_instance" "app" {
 
   engine         = "postgres"
   engine_version = "16.14"
-  instance_class = "db.t4g.micro"
+  instance_class = var.dev_db_instance_class
   db_name        = "guardbench"
   username       = "guardbench"
 
   manage_master_user_password = true
   storage_encrypted           = true
   storage_type                = "gp3"
-  allocated_storage           = 20
-  max_allocated_storage       = 100
+  allocated_storage           = var.dev_db_allocated_storage
+  max_allocated_storage       = var.dev_db_max_allocated_storage
 
   db_subnet_group_name   = aws_db_subnet_group.app.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   publicly_accessible    = false
   multi_az               = false
 
-  backup_retention_period    = 1
+  backup_retention_period    = var.dev_db_backup_retention_period
   auto_minor_version_upgrade = true
   deletion_protection        = false
   skip_final_snapshot        = true
 
   tags = {
     Name = "${var.project}-${var.environment}-postgres"
+  }
+}
+
+resource "aws_db_instance" "performance" {
+  identifier = "${var.project}-${var.environment}-performance"
+
+  engine         = "postgres"
+  engine_version = "16.14"
+  instance_class = var.performance_db_instance_class
+  db_name        = "guardbench"
+  username       = "guardbench"
+
+  manage_master_user_password = true
+  storage_encrypted           = true
+  storage_type                = "gp3"
+  allocated_storage           = var.performance_db_allocated_storage
+  max_allocated_storage       = var.performance_db_max_allocated_storage
+
+  db_subnet_group_name   = aws_db_subnet_group.app.name
+  vpc_security_group_ids = [aws_security_group.performance_rds.id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  backup_retention_period    = var.performance_db_backup_retention_period
+  auto_minor_version_upgrade = true
+  deletion_protection        = false
+  skip_final_snapshot        = true
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-postgres"
+    Purpose = "performance-testing"
   }
 }

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -87,6 +87,16 @@ resource "aws_security_group_rule" "api_egress_to_rds" {
   security_group_id        = aws_security_group.api.id
 }
 
+resource "aws_security_group_rule" "api_egress_to_performance_rds" {
+  type                     = "egress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_rds.id
+  description              = "To performance-test RDS PostgreSQL"
+  security_group_id        = aws_security_group.api.id
+}
+
 # ============================================
 # Worker Security Group (Orchestrator + Executor)
 # ============================================
@@ -143,6 +153,30 @@ resource "aws_security_group_rule" "rds_ingress_from_api" {
   source_security_group_id = aws_security_group.api.id
   description              = "From API service"
   security_group_id        = aws_security_group.rds.id
+}
+
+# ============================================
+# Performance RDS Security Group
+# ============================================
+resource "aws_security_group" "performance_rds" {
+  name        = "${var.project}-${var.environment}-performance-rds-sg"
+  description = "GuardBench performance-test RDS PostgreSQL"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-rds-sg"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_security_group_rule" "performance_rds_ingress_from_api" {
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.api.id
+  description              = "From shared dev API service"
+  security_group_id        = aws_security_group.performance_rds.id
 }
 
 # ============================================

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -21,9 +21,9 @@ app_image_tag = "0123456789abcdef0123456789abcdef01234567"
 # performance-test RDS. Keep dev as the normal deployment default.
 ecs_db_target = "dev"
 
-# Choose performance RDS sizing from an approved performance-test plan before
-# apply. These defaults mirror the existing dev RDS and are not a sizing decision.
-# performance_db_instance_class           = "db.t4g.micro"
-# performance_db_allocated_storage        = 20
-# performance_db_max_allocated_storage    = 100
-# performance_db_backup_retention_period  = 1
+# Performance RDS sizing has no defaults. Set every value from the approved
+# performance-test sizing decision before a plan or apply that creates it.
+# performance_db_instance_class          = "APPROVED_INSTANCE_CLASS"
+# performance_db_allocated_storage       = APPROVED_ALLOCATED_STORAGE_GIB
+# performance_db_max_allocated_storage   = APPROVED_MAX_STORAGE_GIB
+# performance_db_backup_retention_period = APPROVED_BACKUP_RETENTION_DAYS

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -16,3 +16,14 @@ private_subnet_cidrs = ["10.1.10.0/24", "10.1.20.0/24"]
 
 # 검증된 backend commit SHA로 바꿔 사용합니다. latest tag는 허용하지 않습니다.
 app_image_tag = "0123456789abcdef0123456789abcdef01234567"
+
+# The shared dev ECS task can target either the normal dev RDS or the isolated
+# performance-test RDS. Keep dev as the normal deployment default.
+ecs_db_target = "dev"
+
+# Choose performance RDS sizing from an approved performance-test plan before
+# apply. These defaults mirror the existing dev RDS and are not a sizing decision.
+# performance_db_instance_class           = "db.t4g.micro"
+# performance_db_allocated_storage        = 20
+# performance_db_max_allocated_storage    = 100
+# performance_db_backup_retention_period  = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -108,6 +108,65 @@ variable "db_port" {
   default     = 5432
 }
 
+variable "ecs_db_target" {
+  description = "Database target injected into the shared dev ECS task definition"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "performance"], var.ecs_db_target)
+    error_message = "ecs_db_target must be either dev or performance."
+  }
+}
+
+variable "dev_db_instance_class" {
+  description = "Instance class for the development RDS"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "dev_db_allocated_storage" {
+  description = "Allocated storage in GiB for the development RDS"
+  type        = number
+  default     = 20
+}
+
+variable "dev_db_max_allocated_storage" {
+  description = "Maximum autoscaled storage in GiB for the development RDS"
+  type        = number
+  default     = 100
+}
+
+variable "dev_db_backup_retention_period" {
+  description = "Backup retention period in days for the development RDS"
+  type        = number
+  default     = 1
+}
+
+variable "performance_db_instance_class" {
+  description = "Instance class for the performance-test RDS; set this from the test sizing decision before apply"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "performance_db_allocated_storage" {
+  description = "Allocated storage in GiB for the performance-test RDS"
+  type        = number
+  default     = 20
+}
+
+variable "performance_db_max_allocated_storage" {
+  description = "Maximum autoscaled storage in GiB for the performance-test RDS"
+  type        = number
+  default     = 100
+}
+
+variable "performance_db_backup_retention_period" {
+  description = "Backup retention period in days for the performance-test RDS"
+  type        = number
+  default     = 1
+}
+
 variable "spa_index_document" {
   description = "Index document for S3 static hosting"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -144,27 +144,28 @@ variable "dev_db_backup_retention_period" {
 }
 
 variable "performance_db_instance_class" {
-  description = "Instance class for the performance-test RDS; set this from the test sizing decision before apply"
+  description = "Required instance class for the performance-test RDS, set from the approved test sizing decision"
   type        = string
-  default     = "db.t4g.micro"
 }
 
 variable "performance_db_allocated_storage" {
-  description = "Allocated storage in GiB for the performance-test RDS"
+  description = "Required allocated storage in GiB for the performance-test RDS"
   type        = number
-  default     = 20
 }
 
 variable "performance_db_max_allocated_storage" {
-  description = "Maximum autoscaled storage in GiB for the performance-test RDS"
+  description = "Required maximum autoscaled storage in GiB for the performance-test RDS"
   type        = number
-  default     = 100
+
+  validation {
+    condition     = var.performance_db_max_allocated_storage >= var.performance_db_allocated_storage
+    error_message = "performance_db_max_allocated_storage must be greater than or equal to performance_db_allocated_storage."
+  }
 }
 
 variable "performance_db_backup_retention_period" {
-  description = "Backup retention period in days for the performance-test RDS"
+  description = "Required backup retention period in days for the performance-test RDS"
   type        = number
-  default     = 1
 }
 
 variable "spa_index_document" {


### PR DESCRIPTION
## Summary
- add an isolated Performance PostgreSQL RDS and dedicated security group in the existing dev private subnets
- allow PostgreSQL only between the shared dev API security group and the Performance RDS security group
- select the ECS database target with ecs_db_target, keeping endpoint and Secrets Manager credentials bound to the same selected RDS
- allow the shared ECS task execution role to read only the Dev and Performance RDS master secrets, so existing revisions remain restart and circuit-breaker rollback safe during a target switch
- require explicit Performance RDS instance class, allocated storage, maximum storage, and backup retention inputs; no Performance sizing default is applied
- expose Performance RDS identification outputs and document shared ECS/SQS performance-test operating assumptions
- normalize CloudFront Function source line endings so a CRLF checkout does not cause unrelated plan drift

## Verification
- terraform fmt -check
- terraform validate
- a plan without Performance sizing inputs fails before planning and identifies all four required variables

No Terraform apply or live Dev-to-Performance-to-Dev switch verification was performed. Apply approved sizing values, run the Backend workflow to deploy each baseline revision, and verify both DB directions before closing the issue.

Refs #13