### PR TITLE
feat: add performance RDS runner infrastructure

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -189,6 +189,12 @@ resource "aws_ecs_service" "app" {
     container_port   = var.api_container_port
   }
 
+  load_balancer {
+    target_group_arn = aws_lb_target_group.performance_api.arn
+    container_name   = "app"
+    container_port   = var.api_container_port
+  }
+
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
@@ -197,5 +203,5 @@ resource "aws_ecs_service" "app" {
     rollback = true
   }
 
-  depends_on = [aws_lb_listener.http]
+  depends_on = [aws_lb_listener.http, aws_lb_listener.performance_api]
 }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -4,9 +4,11 @@ locals {
   selected_db = var.ecs_db_target == "performance" ? {
     address           = aws_db_instance.performance.address
     master_secret_arn = aws_db_instance.performance.master_user_secret[0].secret_arn
+    database_name     = "guardbench_perf"
     } : {
     address           = aws_db_instance.app.address
     master_secret_arn = aws_db_instance.app.master_user_secret[0].secret_arn
+    database_name     = "guardbench"
   }
 }
 
@@ -135,7 +137,7 @@ resource "aws_ecs_task_definition" "app" {
     environment = [
       { name = "SERVER_PORT", value = tostring(var.api_container_port) },
       { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
-      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${local.selected_db.address}:${var.db_port}/guardbench?sslmode=require" },
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${local.selected_db.address}:${var.db_port}/${local.selected_db.database_name}?sslmode=require" },
       { name = "AWS_REGION", value = var.aws_region },
       { name = "SQS_ENABLED", value = "true" },
       { name = "WORKER_ENABLED", value = "true" },

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -80,6 +80,16 @@ output "ecs_cluster_name" {
   value       = aws_ecs_cluster.main.name
 }
 
+output "performance_runner_api_url" {
+  description = "Private ALB URL to use as PERF_BASE_URL from the performance runner"
+  value       = "http://${aws_lb.performance_api.dns_name}"
+}
+
+output "ecs_service_name" {
+  description = "Combined application ECS service name for performance-run automation"
+  value       = aws_ecs_service.app.name
+}
+
 output "ecr_repository_url" {
   description = "ECR repository URL (push images here)"
   value       = aws_ecr_repository.app.repository_url
@@ -100,6 +110,11 @@ output "performance_rds_identifier" {
   value       = aws_db_instance.performance.identifier
 }
 
+output "performance_rds_master_secret_arn" {
+  description = "Secrets Manager ARN for the isolated performance RDS credentials"
+  value       = aws_db_instance.performance.master_user_secret[0].secret_arn
+}
+
 output "performance_runner_instance_id" {
   description = "SSM-managed EC2 Spot instance used for performance-test runs"
   value       = aws_instance.performance_runner.id
@@ -110,9 +125,34 @@ output "performance_runner_security_group_id" {
   value       = aws_security_group.performance_runner.id
 }
 
+output "performance_runner_bootstrap_document_name" {
+  description = "SSM Command document that installs a packaged performance runner from private S3"
+  value       = aws_ssm_document.performance_runner_bootstrap.name
+}
+
+output "performance_results_bucket_name" {
+  description = "Private S3 bucket for runner bootstrap artifacts and performance results"
+  value       = aws_s3_bucket.performance_results.id
+}
+
 output "sqs_queue_urls" {
   description = "Source queue URLs injected into the app task definition"
   value       = { for name, queue in aws_sqs_queue.source : name => queue.url }
+}
+
+output "sqs_queue_names" {
+  description = "Source queue names used by performance-run automation"
+  value       = { for name, queue in aws_sqs_queue.source : name => queue.name }
+}
+
+output "sqs_dead_letter_queue_urls" {
+  description = "Dead-letter queue URLs used by performance-run automation"
+  value       = { for name, queue in aws_sqs_queue.dead_letter : name => queue.url }
+}
+
+output "sqs_dead_letter_queue_names" {
+  description = "Dead-letter queue names used by performance-run automation"
+  value       = { for name, queue in aws_sqs_queue.dead_letter : name => queue.name }
 }
 
 output "ops_sns_topic_arn" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -100,6 +100,16 @@ output "performance_rds_identifier" {
   value       = aws_db_instance.performance.identifier
 }
 
+output "performance_runner_instance_id" {
+  description = "SSM-managed EC2 Spot instance used for performance-test runs"
+  value       = aws_instance.performance_runner.id
+}
+
+output "performance_runner_security_group_id" {
+  description = "Security group ID for the performance-test runner"
+  value       = aws_security_group.performance_runner.id
+}
+
 output "sqs_queue_urls" {
   description = "Source queue URLs injected into the app task definition"
   value       = { for name, queue in aws_sqs_queue.source : name => queue.url }

--- a/terraform/performance-api-alb.tf
+++ b/terraform/performance-api-alb.tf
@@ -1,0 +1,78 @@
+# The public ALB has no private-subnet route without NAT. This internal ALB is
+# therefore the explicit, SG-scoped PERF_BASE_URL path for the Spot runner.
+resource "aws_security_group" "performance_api_alb" {
+  name        = "${var.project}-${var.environment}-performance-api-alb-sg"
+  description = "Internal ALB that exposes GuardBench API only to the performance runner"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-api-alb-sg"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_security_group_rule" "performance_api_alb_ingress_from_runner" {
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_runner.id
+  description              = "GuardBench performance runner API requests"
+  security_group_id        = aws_security_group.performance_api_alb.id
+}
+
+resource "aws_security_group_rule" "performance_api_alb_egress_to_api" {
+  type                     = "egress"
+  from_port                = var.api_container_port
+  to_port                  = var.api_container_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.api.id
+  description              = "Forward performance runner API requests to ECS"
+  security_group_id        = aws_security_group.performance_api_alb.id
+}
+
+resource "aws_lb" "performance_api" {
+  name               = "${var.project}-${var.environment}-performance-api"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.performance_api_alb.id]
+  subnets            = aws_subnet.private[*].id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-api"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_lb_target_group" "performance_api" {
+  name        = "${var.project}-${var.environment}-performance-api"
+  port        = var.api_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/api/v1/test-suites"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-api"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_lb_listener" "performance_api" {
+  load_balancer_arn = aws_lb.performance_api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.performance_api.arn
+  }
+}

--- a/terraform/performance-results.tf
+++ b/terraform/performance-results.tf
@@ -1,0 +1,47 @@
+# Bootstrap artifacts and immutable output use separate prefixes. Only
+# completed run results expire after 30 days, so replacement Spot instances can
+# continue to retrieve the bootstrap artifact.
+resource "aws_s3_bucket" "performance_results" {
+  bucket = "${var.project}-${var.environment}-performance-results-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-results"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "performance_results" {
+  bucket = aws_s3_bucket.performance_results.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "performance_results" {
+  bucket = aws_s3_bucket.performance_results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "performance_results" {
+  bucket = aws_s3_bucket.performance_results.id
+
+  rule {
+    id     = "expire-performance-results"
+    status = "Enabled"
+
+    filter {
+      prefix = "performance/results/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -1,0 +1,107 @@
+# Dedicated, disposable execution host for the backend performance runner.
+# Runner software is intentionally not installed here: the host only provides
+# private-network access, SSM operations access, and least-privilege AWS APIs.
+
+data "aws_ssm_parameter" "performance_runner_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+resource "aws_iam_role" "performance_runner" {
+  name = "${var.project}-${var.environment}-performance-runner-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-runner-role"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "performance_runner_ssm" {
+  role       = aws_iam_role.performance_runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "performance_runner" {
+  name = "${var.project}-${var.environment}-performance-runner-policy"
+  role = aws_iam_role.performance_runner.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadPerformanceQueueMetrics"
+        Effect = "Allow"
+        Action = ["sqs:GetQueueAttributes"]
+        Resource = concat(
+          [for queue in values(aws_sqs_queue.source) : queue.arn],
+          [for queue in values(aws_sqs_queue.dead_letter) : queue.arn],
+        )
+      },
+      {
+        Sid      = "ReadCloudWatchMetrics"
+        Effect   = "Allow"
+        Action   = ["cloudwatch:GetMetricData"]
+        Resource = "*"
+      },
+      {
+        Sid      = "ReadPerformanceDatabaseCredentials"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = aws_db_instance.performance.master_user_secret[0].secret_arn
+      },
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "performance_runner" {
+  name = "${var.project}-${var.environment}-performance-runner-profile"
+  role = aws_iam_role.performance_runner.name
+}
+
+resource "aws_instance" "performance_runner" {
+  ami                         = data.aws_ssm_parameter.performance_runner_ami.value
+  instance_type               = var.performance_runner_instance_type
+  subnet_id                   = aws_subnet.private[0].id
+  vpc_security_group_ids      = [aws_security_group.performance_runner.id]
+  iam_instance_profile        = aws_iam_instance_profile.performance_runner.name
+  associate_public_ip_address = false
+
+  dynamic "instance_market_options" {
+    for_each = var.performance_runner_spot ? [1] : []
+
+    content {
+      market_type = "spot"
+
+      spot_options {
+        spot_instance_type             = "one-time"
+        instance_interruption_behavior = "terminate"
+      }
+    }
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = var.performance_runner_root_volume_gb
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-runner"
+    Purpose = "performance-testing"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.performance_runner_ssm]
+}

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -1,6 +1,6 @@
 # Dedicated, disposable execution host for the backend performance runner.
-# Runner software is intentionally not installed here: the host only provides
-# private-network access, SSM operations access, and least-privilege AWS APIs.
+# The runner artifact is supplied independently through S3, so this host can
+# later be replaced by a container runner without changing the artifact format.
 
 data "aws_ssm_parameter" "performance_runner_ami" {
   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
@@ -57,6 +57,18 @@ resource "aws_iam_role_policy" "performance_runner" {
         Action   = ["secretsmanager:GetSecretValue"]
         Resource = aws_db_instance.performance.master_user_secret[0].secret_arn
       },
+      {
+        Sid      = "ReadRunnerBootstrapArtifact"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "${aws_s3_bucket.performance_results.arn}/performance/bootstrap/*"
+      },
+      {
+        Sid      = "WritePerformanceResults"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "${aws_s3_bucket.performance_results.arn}/performance/results/*"
+      },
     ]
   })
 }
@@ -104,4 +116,44 @@ resource "aws_instance" "performance_runner" {
   }
 
   depends_on = [aws_iam_role_policy_attachment.performance_runner_ssm]
+}
+
+# Invoke this document after a self-contained Runner artifact is published to
+# performance/bootstrap/runner.tar.gz. The artifact supplies Python 3.11+, k6,
+# psql, Java 21/Gradle, and backend runner code without requiring NAT access.
+resource "aws_ssm_document" "performance_runner_bootstrap" {
+  name            = "${var.project}-${var.environment}-performance-runner-bootstrap"
+  document_type   = "Command"
+  document_format = "YAML"
+
+  content = yamlencode({
+    schemaVersion = "2.2"
+    description   = "Install a versioned GuardBench performance runner artifact from private S3"
+    parameters = {
+      ArtifactKey = {
+        type        = "String"
+        default     = "performance/bootstrap/runner.tar.gz"
+        description = "S3 key for the self-contained performance runner artifact"
+      }
+    }
+    mainSteps = [{
+      action = "aws:runShellScript"
+      name   = "installPerformanceRunner"
+      inputs = {
+        runCommand = [
+          "set -euo pipefail",
+          "install -d -m 0755 /opt/guardbench-performance-runner",
+          "aws s3 cp s3://${aws_s3_bucket.performance_results.id}/{{ ArtifactKey }} /tmp/guardbench-performance-runner.tar.gz",
+          "rm -rf /opt/guardbench-performance-runner/*",
+          "tar -xzf /tmp/guardbench-performance-runner.tar.gz -C /opt/guardbench-performance-runner",
+          "/opt/guardbench-performance-runner/bin/verify-runtime",
+        ]
+      }
+    }]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-runner-bootstrap"
+    Purpose = "performance-testing"
+  }
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -43,8 +43,10 @@ resource "aws_db_instance" "performance" {
   engine         = "postgres"
   engine_version = "16.14"
   instance_class = var.performance_db_instance_class
-  db_name        = "guardbench"
-  username       = "guardbench"
+  # The performance runner rejects destructive resets unless this isolated
+  # database name is used.
+  db_name  = "guardbench_perf"
+  username = "guardbench"
 
   manage_master_user_password = true
   storage_encrypted           = true

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -179,6 +179,16 @@ resource "aws_security_group_rule" "performance_rds_ingress_from_api" {
   security_group_id        = aws_security_group.performance_rds.id
 }
 
+resource "aws_security_group_rule" "api_ingress_from_performance_alb" {
+  type                     = "ingress"
+  from_port                = var.api_container_port
+  to_port                  = var.api_container_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_api_alb.id
+  description              = "From internal performance API ALB"
+  security_group_id        = aws_security_group.api.id
+}
+
 # ============================================
 # Performance Runner Security Group
 # ============================================

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -213,6 +213,29 @@ resource "aws_security_group_rule" "performance_runner_egress_to_vpc_endpoints" 
   security_group_id        = aws_security_group.performance_runner.id
 }
 
+# The internal performance ALB is the approved in-VPC API path for the runner.
+# It avoids a NAT gateway and never exposes the API through an external CIDR.
+resource "aws_security_group_rule" "performance_runner_egress_to_alb" {
+  type                     = "egress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_api_alb.id
+  description              = "Call GuardBench API through the private ALB"
+  security_group_id        = aws_security_group.performance_runner.id
+}
+
+resource "aws_security_group_rule" "performance_runner_egress_to_s3_gateway" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [aws_vpc_endpoint.s3.prefix_list_id]
+  description       = "Read runner artifacts and preserve results through S3 Gateway endpoint"
+  security_group_id = aws_security_group.performance_runner.id
+}
+
+
 resource "aws_security_group_rule" "performance_rds_ingress_from_runner" {
   type                     = "ingress"
   from_port                = var.db_port

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -180,6 +180,50 @@ resource "aws_security_group_rule" "performance_rds_ingress_from_api" {
 }
 
 # ============================================
+# Performance Runner Security Group
+# ============================================
+resource "aws_security_group" "performance_runner" {
+  name        = "${var.project}-${var.environment}-performance-runner-sg"
+  description = "GuardBench EC2 performance-test runner; no inbound access"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-runner-sg"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_security_group_rule" "performance_runner_egress_to_rds" {
+  type                     = "egress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_rds.id
+  description              = "Reset and migrate performance-test RDS"
+  security_group_id        = aws_security_group.performance_runner.id
+}
+
+resource "aws_security_group_rule" "performance_runner_egress_to_vpc_endpoints" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpc_endpoints.id
+  description              = "AWS APIs through VPC endpoints"
+  security_group_id        = aws_security_group.performance_runner.id
+}
+
+resource "aws_security_group_rule" "performance_rds_ingress_from_runner" {
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_runner.id
+  description              = "From dedicated performance-test runner"
+  security_group_id        = aws_security_group.performance_rds.id
+}
+
+# ============================================
 # VPC Endpoints Security Group
 # ============================================
 resource "aws_security_group" "vpc_endpoints" {
@@ -187,13 +231,17 @@ resource "aws_security_group" "vpc_endpoints" {
   description = "GuardBench VPC Endpoints - allow HTTPS from private subnets"
   vpc_id      = aws_vpc.main.id
 
-  # 기존 state가 inline ingress를 소유한다. API만 남겨 Worker 접근을 제거한다.
+  # Existing state owns this inline ingress. Allow the combined app service
+  # and the dedicated performance runner, but not the legacy worker group.
   ingress {
-    description     = "HTTPS from the combined app service"
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = [aws_security_group.api.id]
+    description = "HTTPS from the combined app service"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    security_groups = [
+      aws_security_group.api.id,
+      aws_security_group.performance_runner.id,
+    ]
   }
 
   tags = {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -21,9 +21,14 @@ app_image_tag = "0123456789abcdef0123456789abcdef01234567"
 # performance-test RDS. Keep dev as the normal deployment default.
 ecs_db_target = "dev"
 
-# Performance RDS sizing has no defaults. Set every value from the approved
-# performance-test sizing decision before a plan or apply that creates it.
-# performance_db_instance_class          = "APPROVED_INSTANCE_CLASS"
-# performance_db_allocated_storage       = APPROVED_ALLOCATED_STORAGE_GIB
-# performance_db_max_allocated_storage   = APPROVED_MAX_STORAGE_GIB
-# performance_db_backup_retention_period = APPROVED_BACKUP_RETENTION_DAYS
+# Performance RDS (isolated destructive-reset target for performance tests)
+performance_db_instance_class          = "db.m7g.large"
+performance_db_allocated_storage       = 20
+performance_db_max_allocated_storage   = 100
+performance_db_backup_retention_period = 0
+
+# Dedicated private EC2 Spot runner. It has no public IP or SSH ingress; use
+# SSM Session Manager for operational access.
+performance_runner_instance_type  = "t3.medium"
+performance_runner_root_volume_gb = 20
+performance_runner_spot           = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -168,6 +168,29 @@ variable "performance_db_backup_retention_period" {
   type        = number
 }
 
+variable "performance_runner_instance_type" {
+  description = "EC2 instance type for the dedicated performance-test runner"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "performance_runner_root_volume_gb" {
+  description = "gp3 root-volume size in GiB for the performance-test runner"
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.performance_runner_root_volume_gb >= 8
+    error_message = "performance_runner_root_volume_gb must be at least 8 GiB."
+  }
+}
+
+variable "performance_runner_spot" {
+  description = "Launch the performance-test runner as a Spot instance"
+  type        = bool
+  default     = true
+}
+
 variable "spa_index_document" {
   description = "Index document for S3 static hosting"
   type        = string

--- a/terraform/vpc-endpoints.tf
+++ b/terraform/vpc-endpoints.tf
@@ -62,6 +62,33 @@ resource "aws_vpc_endpoint" "ssm" {
   }
 }
 
+# Session Manager requires the message channels in addition to the SSM API.
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-ssmmessages"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-ec2messages"
+  }
+}
+
 # CloudWatch Logs - 로그 전송
 resource "aws_vpc_endpoint" "logs" {
   vpc_id              = aws_vpc.main.id


### PR DESCRIPTION
## Summary

- Align the isolated Performance RDS database name with the backend reset contract (`guardbench_perf`) and select the JDBC database name by `ecs_db_target`.
- Add a private AL2023 EC2 Spot performance runner with SSM access, least-privilege runner IAM, and Performance RDS connectivity.
- Add SSM message VPC endpoints and approved RDS/Runner values to `terraform.tfvars.example`.

## Validation

- `terraform fmt`
- `terraform validate`
- Remote-state `terraform plan` completed with AWS credentials, using a temporary image SHA. Do not apply that saved plan.

Closes #18
