### PR TITLE
fix: make performance runner opt-in

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,6 +45,8 @@ terraform apply
 
 기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. shared ECS task execution role에는 Dev와 Performance RDS의 두 master secret만 허용해, 전환 중 기존 revision 재시작 또는 circuit breaker rollback도 안전하게 지원한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다.
 
+전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
+
 ## 프론트엔드 GitHub Actions OIDC 배포
 
 계정에 `token.actions.githubusercontent.com` OIDC provider가 이미 있는지 먼저 확인한다.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -117,7 +117,7 @@ output "performance_rds_master_secret_arn" {
 
 output "performance_runner_instance_id" {
   description = "SSM-managed EC2 Spot instance used for performance-test runs"
-  value       = aws_instance.performance_runner.id
+  value       = var.performance_runner_enabled ? aws_instance.performance_runner[0].id : null
 }
 
 output "performance_runner_security_group_id" {

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -79,6 +79,7 @@ resource "aws_iam_instance_profile" "performance_runner" {
 }
 
 resource "aws_instance" "performance_runner" {
+  count                       = var.performance_runner_enabled ? 1 : 0
   ami                         = data.aws_ssm_parameter.performance_runner_ami.value
   instance_type               = var.performance_runner_instance_type
   subnet_id                   = aws_subnet.private[0].id

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -28,7 +28,9 @@ performance_db_max_allocated_storage   = 100
 performance_db_backup_retention_period = 0
 
 # Dedicated private EC2 Spot runner. It has no public IP or SSH ingress; use
-# SSM Session Manager for operational access.
+# SSM Session Manager for operational access. It is opt-in so a normal dev
+# apply does not create the performance-test host.
 performance_runner_instance_type  = "t3.medium"
 performance_runner_root_volume_gb = 20
 performance_runner_spot           = true
+performance_runner_enabled       = false

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -174,6 +174,12 @@ variable "performance_runner_instance_type" {
   default     = "t3.medium"
 }
 
+variable "performance_runner_enabled" {
+  description = "Create the dedicated performance-test runner EC2 instance"
+  type        = bool
+  default     = false
+}
+
 variable "performance_runner_root_volume_gb" {
   description = "gp3 root-volume size in GiB for the performance-test runner"
   type        = number


### PR DESCRIPTION
## Summary

- Prevent the performance-test runner EC2 from being created by default.
- Add an explicit `performance_runner_enabled` opt-in flag.
- Keep the instance ID output safe when the runner is disabled.
- Document the dev default and opt-in workflow.

## Validation

- `terraform fmt -check terraform/*.tf`
- `terraform validate`
- `git diff --check`