### PR TITLE
feat: run performance tests from private Docker image

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,7 +45,18 @@ terraform apply
 
 기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. shared ECS task execution role에는 Dev와 Performance RDS의 두 master secret만 허용해, 전환 중 기존 revision 재시작 또는 circuit breaker rollback도 안전하게 지원한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다.
 
-전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
+전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. Backend의 `performance/build-runner-image.sh`로 이미지를 빌드하고 Terraform output의 전용 ECR repository에 Backend commit SHA tag로 push한 뒤, 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
+
+```bash
+runner_repository="$(terraform output -raw performance_runner_ecr_repository_url)"
+runner_revision="$(git -C ../guardbench-backend rev-parse HEAD)"
+../guardbench-backend/performance/build-runner-image.sh "$runner_repository"
+aws ecr get-login-password --region ap-northeast-2 \
+  | docker login --username AWS --password-stdin "${runner_repository%%/*}"
+../guardbench-backend/bin/publish-runner-image "$runner_repository:$runner_revision"
+```
+
+Runner EC2는 ECS Optimized AL2023 AMI를 사용하므로 private subnet에서 별도 Docker 패키지 다운로드가 필요 없다. Terraform apply 후 SSM Command document를 `RunnerImage=$runner_repository:$runner_revision` 파라미터로 실행하면 ECR pull과 image `verify-runtime` 검증이 수행된다. 실제 Runner 실행에 필요한 `PERF_*` 환경변수와 profile/dataset은 Backend 성능테스트 문서의 실행 절차를 따른다.
 
 ## 프론트엔드 GitHub Actions OIDC 배포
 

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -38,3 +38,42 @@ resource "aws_ecr_lifecycle_policy" "app" {
     ]
   })
 }
+
+# Dedicated repository for the Dockerized performance runner. Keep it separate
+# from the application repository because both images use the backend commit
+# SHA as an immutable tag.
+resource "aws_ecr_repository" "performance_runner" {
+  name                 = "${var.project}-${var.environment}-performance-runner"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-runner-ecr"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "performance_runner" {
+  repository = aws_ecr_repository.performance_runner.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the last 10 performance runner images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -126,12 +126,17 @@ output "performance_runner_security_group_id" {
 }
 
 output "performance_runner_bootstrap_document_name" {
-  description = "SSM Command document that installs a packaged performance runner from private S3"
+  description = "SSM Command document that pulls and verifies the performance runner Docker image"
   value       = aws_ssm_document.performance_runner_bootstrap.name
 }
 
+output "performance_runner_ecr_repository_url" {
+  description = "Private ECR repository URL for immutable performance runner images"
+  value       = aws_ecr_repository.performance_runner.repository_url
+}
+
 output "performance_results_bucket_name" {
-  description = "Private S3 bucket for runner bootstrap artifacts and performance results"
+  description = "Private S3 bucket for performance results"
   value       = aws_s3_bucket.performance_results.id
 }
 

--- a/terraform/performance-results.tf
+++ b/terraform/performance-results.tf
@@ -1,6 +1,5 @@
-# Bootstrap artifacts and immutable output use separate prefixes. Only
-# completed run results expire after 30 days, so replacement Spot instances can
-# continue to retrieve the bootstrap artifact.
+# Performance run output is kept in a private bucket. Only completed run
+# results expire after 30 days; runner images are stored in ECR.
 resource "aws_s3_bucket" "performance_results" {
   bucket = "${var.project}-${var.environment}-performance-results-${data.aws_caller_identity.current.account_id}"
 

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -1,9 +1,10 @@
 # Dedicated, disposable execution host for the backend performance runner.
-# The runner artifact is supplied independently through S3, so this host can
-# later be replaced by a container runner without changing the artifact format.
+# The host pulls a versioned Docker image from the private ECR repository.
 
 data "aws_ssm_parameter" "performance_runner_ami" {
-  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+  # ECS Optimized AL2023 includes Docker and avoids package downloads from a
+  # private subnet without NAT. The host uses Docker directly, not ECS.
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
 }
 
 resource "aws_iam_role" "performance_runner" {
@@ -37,6 +38,22 @@ resource "aws_iam_role_policy" "performance_runner" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "PullPerformanceRunnerImage"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+        ]
+        Resource = aws_ecr_repository.performance_runner.arn
+      },
+      {
+        Sid      = "AuthorizeEcrPull"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
         Sid    = "ReadPerformanceQueueMetrics"
         Effect = "Allow"
         Action = ["sqs:GetQueueAttributes"]
@@ -56,12 +73,6 @@ resource "aws_iam_role_policy" "performance_runner" {
         Effect   = "Allow"
         Action   = ["secretsmanager:GetSecretValue"]
         Resource = aws_db_instance.performance.master_user_secret[0].secret_arn
-      },
-      {
-        Sid      = "ReadRunnerBootstrapArtifact"
-        Effect   = "Allow"
-        Action   = ["s3:GetObject"]
-        Resource = "${aws_s3_bucket.performance_results.arn}/performance/bootstrap/*"
       },
       {
         Sid      = "WritePerformanceResults"
@@ -86,6 +97,13 @@ resource "aws_instance" "performance_runner" {
   vpc_security_group_ids      = [aws_security_group.performance_runner.id]
   iam_instance_profile        = aws_iam_instance_profile.performance_runner.name
   associate_public_ip_address = false
+
+  user_data = <<-USERDATA
+    #!/bin/bash
+    set -euo pipefail
+    systemctl enable --now docker
+    usermod -aG docker ec2-user || true
+  USERDATA
 
   dynamic "instance_market_options" {
     for_each = var.performance_runner_spot ? [1] : []
@@ -119,9 +137,9 @@ resource "aws_instance" "performance_runner" {
   depends_on = [aws_iam_role_policy_attachment.performance_runner_ssm]
 }
 
-# Invoke this document after a self-contained Runner artifact is published to
-# performance/bootstrap/runner.tar.gz. The artifact supplies Python 3.11+, k6,
-# psql, Java 21/Gradle, and backend runner code without requiring NAT access.
+# Invoke this document after an immutable Runner image is pushed to the
+# dedicated private ECR repository. The image supplies Python 3.11+, k6, psql,
+# Java 21/Gradle, and backend runner code without requiring NAT access.
 resource "aws_ssm_document" "performance_runner_bootstrap" {
   name            = "${var.project}-${var.environment}-performance-runner-bootstrap"
   document_type   = "Command"
@@ -129,25 +147,27 @@ resource "aws_ssm_document" "performance_runner_bootstrap" {
 
   content = yamlencode({
     schemaVersion = "2.2"
-    description   = "Install a versioned GuardBench performance runner artifact from private S3"
+    description   = "Pull and verify a versioned GuardBench performance runner image from private ECR"
     parameters = {
-      ArtifactKey = {
+      RunnerImage = {
         type        = "String"
-        default     = "performance/bootstrap/runner.tar.gz"
-        description = "S3 key for the self-contained performance runner artifact"
+        description = "Full immutable ECR image URI for the performance runner"
       }
     }
     mainSteps = [{
       action = "aws:runShellScript"
-      name   = "installPerformanceRunner"
+      name   = "preparePerformanceRunner"
       inputs = {
         runCommand = [
           "set -euo pipefail",
+          "runner_image='{{ RunnerImage }}'",
+          "case \"$runner_image\" in \"${aws_ecr_repository.performance_runner.repository_url}:\"*) ;; *) echo 'RunnerImage must use the dedicated performance-runner ECR repository.' >&2; exit 1 ;; esac",
+          "registry=\"$${runner_image%%/*}\"",
+          "aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin \"$registry\"",
+          "docker pull \"$runner_image\"",
+          "docker run --rm --entrypoint /workspace/bin/verify-runtime \"$runner_image\"",
           "install -d -m 0755 /opt/guardbench-performance-runner",
-          "aws s3 cp s3://${aws_s3_bucket.performance_results.id}/{{ ArtifactKey }} /tmp/guardbench-performance-runner.tar.gz",
-          "rm -rf /opt/guardbench-performance-runner/*",
-          "tar -xzf /tmp/guardbench-performance-runner.tar.gz -C /opt/guardbench-performance-runner",
-          "/opt/guardbench-performance-runner/bin/verify-runtime",
+          "printf '%s\\n' \"$runner_image\" > /opt/guardbench-performance-runner/image",
         ]
       }
     }]

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -241,7 +241,7 @@ resource "aws_security_group_rule" "performance_runner_egress_to_s3_gateway" {
   to_port           = 443
   protocol          = "tcp"
   prefix_list_ids   = [aws_vpc_endpoint.s3.prefix_list_id]
-  description       = "Read runner artifacts and preserve results through S3 Gateway endpoint"
+  description       = "ECR image layers and performance results through S3 Gateway endpoint"
   security_group_id = aws_security_group.performance_runner.id
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated immutable ECR repository for the Dockerized performance runner
- use ECS Optimized AL2023 so the private Spot host has Docker without NAT package downloads
- grant least-privilege ECR pull access and update the SSM bootstrap document to pull and verify the runner image
- update outputs, security-group descriptions, and the Terraform runbook for the Docker workflow

## Validation
- `terraform fmt -check`
- `terraform validate`
- `git diff --check`

## Operational note
Pass the full immutable image URI as the SSM `RunnerImage` parameter after publishing the backend runner image.