### PR TITLE
feat(terraform): integrate Demo AI performance target

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -47,6 +47,34 @@ terraform apply
 
 전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. Backend의 `performance/build-runner-image.sh`로 이미지를 빌드하고 Terraform output의 전용 ECR repository에 Backend commit SHA tag로 push한 뒤, 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
 
+## Demo AI 성능 테스트 Target
+
+Demo AI는 기존 `guardbench-dev-cluster`를 재사용하는 별도 Fargate Task Definition/Service다. Backend `guardbench-dev-app`의 sidecar가 아니며, 전용 task role·execution role·CloudWatch Log Group·security group을 사용한다. Demo AI image는 `guardbench-demo-ai-service` 전용 ECR repository의 immutable Git SHA tag로 지정한다. 기존 `performance_runner_enabled` 패턴에 맞춰 `demo_ai_enabled = false`가 기본값이며, 성능 테스트 시 `true`로 켜고 종료 후 다시 끌 수 있다.
+
+기존 `guardbench-dev-performance-api` internal ALB를 재사용하고 `/v1/chat/completions` path rule만 Demo AI target group으로 전달한다. 기존 ALB default action과 Backend target group은 변경하지 않는다. ALB health check는 Demo AI의 `GET /health`를 사용한다. Runner SG에서 internal ALB SG로 HTTP 80, ALB SG에서 Demo AI task SG로 TCP 8080만 허용되며, Demo AI task는 private subnet에서 `assign_public_ip = false`로 실행된다.
+
+Demo AI task의 유일한 AWS API 권한은 입력된 정확한 `demo_ai_bedrock_resource_arns`에 대한 `bedrock:InvokeModel`이다. ECR pull과 CloudWatch Logs에는 Demo AI 전용 execution role을 사용하므로 Backend RDS secret 권한을 공유하지 않는다. task는 기존 `bedrock-runtime`, ECR, Logs VPC Endpoint와 S3 Gateway Endpoint를 사용하며 NAT 또는 인터넷 경로에 의존하지 않는다.
+
+다음 변수는 실제 환경 계약을 확인한 값으로 명시해야 한다.
+
+- `demo_ai_image_tag`: Demo AI repository에 push한 verified Git SHA
+- `demo_ai_bedrock_model_id`: container의 `BEDROCK_MODEL_ID` 값
+- `demo_ai_bedrock_resource_arns`: 해당 model 또는 cross-region inference profile의 정확한 허용 ARN 목록
+
+ECR repository 자체도 Terraform 소유이므로 첫 배포는 repository 생성과 image push를 분리한다. 먼저 검토된 plan에서 `aws_ecr_repository.demo_ai`와 lifecycle policy만 bootstrap apply하고, output의 `demo_ai_ecr_repository_url`에 `d9d9b4a6a36f8f7fe5548d218106dcc500ef4228` image를 push한다. 그 다음 `demo_ai_image_tag`를 입력하고 `demo_ai_enabled = true`로 설정한 전체 plan/apply에서 ECS Service를 시작한다. image push 전에는 이 SHA로 ECS Service를 apply하지 않는다.
+
+자동 Demo AI CI/CD는 이 Terraform 변경에 포함하지 않는다. 현재 Demo AI 배포 revision은 Terraform이 task definition과 service를 소유한다. 별도 CI가 revision을 소유하게 되면, 이 task definition/service의 deployment ownership과 `ignore_changes` 정책을 함께 재검토해야 한다.
+
+Runner가 사용할 값은 apply 후 다음 output으로 확인한다.
+
+```bash
+terraform output -raw performance_target_url
+terraform output -raw performance_target_model
+terraform output -raw performance_target_revision
+```
+
+이는 각각 `PERF_TARGET_URL`, `PERF_TARGET_MODEL`, `PERF_TARGET_REVISION`에 매핑된다. 현재 값은 `http://<internal-performance-alb>/v1/chat/completions`, `demo-model`, Demo AI immutable image tag다. Runner는 Demo AI container를 실행하지 않고 HTTP client 역할만 수행한다.
+
 ```bash
 runner_repository="$(terraform output -raw performance_runner_ecr_repository_url)"
 runner_revision="$(git -C ../guardbench-backend rev-parse HEAD)"

--- a/terraform/demo-ai.tf
+++ b/terraform/demo-ai.tf
@@ -1,0 +1,149 @@
+# OpenAI-compatible Demo AI target for integrated performance tests.
+# This service deliberately has its own task definition, service, task role,
+# execution role, log group, and security group. It reuses the existing dev
+# ECS cluster and private subnets but never becomes a backend sidecar.
+
+locals {
+  demo_ai_container_port = 8080
+}
+
+resource "aws_cloudwatch_log_group" "demo_ai" {
+  name              = "/ecs/${var.project}-${var.environment}/demo-ai"
+  retention_in_days = 14
+
+  tags = {
+    Name    = "/ecs/${var.project}-${var.environment}/demo-ai"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_iam_role" "demo_ai_task_execution" {
+  name = "${var.project}-${var.environment}-demo-ai-exec-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-demo-ai-exec-role"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "demo_ai_task_execution" {
+  role       = aws_iam_role.demo_ai_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "demo_ai_task" {
+  name = "${var.project}-${var.environment}-demo-ai-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-demo-ai-task-role"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_iam_role_policy" "demo_ai_task" {
+  name = "${var.project}-${var.environment}-demo-ai-task-policy"
+  role = aws_iam_role.demo_ai_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "InvokeApprovedBedrockModels"
+      Effect   = "Allow"
+      Action   = ["bedrock:InvokeModel"]
+      Resource = var.demo_ai_bedrock_resource_arns
+    }]
+  })
+}
+
+resource "aws_ecs_task_definition" "demo_ai" {
+  family                   = "${var.project}-${var.environment}-demo-ai"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.demo_ai_cpu
+  memory                   = var.demo_ai_memory
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  execution_role_arn = aws_iam_role.demo_ai_task_execution.arn
+  task_role_arn      = aws_iam_role.demo_ai_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "demo-ai"
+    image     = "${aws_ecr_repository.demo_ai.repository_url}:${var.demo_ai_image_tag}"
+    essential = true
+
+    portMappings = [{
+      containerPort = local.demo_ai_container_port
+      protocol      = "tcp"
+    }]
+
+    environment = [
+      { name = "AWS_REGION", value = var.aws_region },
+      { name = "BEDROCK_MODEL_ID", value = var.demo_ai_bedrock_model_id },
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.demo_ai.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "demo-ai"
+      }
+    }
+  }])
+}
+
+resource "aws_ecs_service" "demo_ai" {
+  name            = "${var.project}-${var.environment}-demo-ai"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.demo_ai.arn
+  desired_count   = var.demo_ai_enabled ? var.demo_ai_desired_count : 0
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.demo_ai.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.performance_demo_ai.arn
+    container_name   = "demo-ai"
+    container_port   = local.demo_ai_container_port
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  depends_on = [
+    aws_lb_listener.performance_api,
+    aws_lb_listener_rule.performance_demo_ai,
+    aws_iam_role_policy_attachment.demo_ai_task_execution,
+  ]
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -77,3 +77,41 @@ resource "aws_ecr_lifecycle_policy" "performance_runner" {
     ]
   })
 }
+
+# Dedicated repository for the OpenAI-compatible performance-test target.
+# Keep it separate from both the backend and performance runner images.
+resource "aws_ecr_repository" "demo_ai" {
+  name                 = "${var.project}-demo-ai-service"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name    = "${var.project}-demo-ai-service-ecr"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "demo_ai" {
+  repository = aws_ecr_repository.demo_ai.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the last 10 Demo AI images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -135,6 +135,36 @@ output "performance_runner_ecr_repository_url" {
   value       = aws_ecr_repository.performance_runner.repository_url
 }
 
+output "demo_ai_ecr_repository_url" {
+  description = "Private ECR repository URL for immutable Demo AI images"
+  value       = aws_ecr_repository.demo_ai.repository_url
+}
+
+output "demo_ai_ecs_service_name" {
+  description = "Dedicated Demo AI ECS service name"
+  value       = aws_ecs_service.demo_ai.name
+}
+
+output "demo_ai_log_group_name" {
+  description = "CloudWatch Log Group for Demo AI task metadata"
+  value       = aws_cloudwatch_log_group.demo_ai.name
+}
+
+output "performance_target_url" {
+  description = "Private internal endpoint for PERF_TARGET_URL"
+  value       = "http://${aws_lb.performance_api.dns_name}/v1/chat/completions"
+}
+
+output "performance_target_model" {
+  description = "OpenAI-compatible model value for PERF_TARGET_MODEL"
+  value       = "demo-model"
+}
+
+output "performance_target_revision" {
+  description = "Immutable Demo AI image tag for performance-test traceability"
+  value       = var.demo_ai_image_tag
+}
+
 output "performance_results_bucket_name" {
   description = "Private S3 bucket for performance results"
   value       = aws_s3_bucket.performance_results.id

--- a/terraform/performance-api-alb.tf
+++ b/terraform/performance-api-alb.tf
@@ -31,6 +31,16 @@ resource "aws_security_group_rule" "performance_api_alb_egress_to_api" {
   security_group_id        = aws_security_group.performance_api_alb.id
 }
 
+resource "aws_security_group_rule" "performance_api_alb_egress_to_demo_ai" {
+  type                     = "egress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.demo_ai.id
+  description              = "Forward the Demo AI target route to ECS"
+  security_group_id        = aws_security_group.performance_api_alb.id
+}
+
 resource "aws_lb" "performance_api" {
   name               = "${var.project}-${var.environment}-performance-api"
   internal           = true
@@ -66,6 +76,30 @@ resource "aws_lb_target_group" "performance_api" {
   }
 }
 
+resource "aws_lb_target_group" "performance_demo_ai" {
+  name        = "${var.project}-${var.environment}-demo-ai"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-demo-ai"
+    Purpose = "performance-testing"
+  }
+}
+
 resource "aws_lb_listener" "performance_api" {
   load_balancer_arn = aws_lb.performance_api.arn
   port              = 80
@@ -74,5 +108,23 @@ resource "aws_lb_listener" "performance_api" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.performance_api.arn
+  }
+}
+
+# Reuse the existing Runner-only internal ALB. The default action remains the
+# GuardBench backend target, so this path rule cannot alter normal API traffic.
+resource "aws_lb_listener_rule" "performance_demo_ai" {
+  listener_arn = aws_lb_listener.performance_api.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.performance_demo_ai.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/v1/chat/completions"]
+    }
   }
 }

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -190,6 +190,50 @@ resource "aws_security_group_rule" "api_ingress_from_performance_alb" {
 }
 
 # ============================================
+# Demo AI Service Security Group (ECS Fargate)
+# ============================================
+resource "aws_security_group" "demo_ai" {
+  name        = "${var.project}-${var.environment}-demo-ai-sg"
+  description = "GuardBench Demo AI performance-test Fargate service"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-demo-ai-sg"
+    Purpose = "performance-testing"
+  }
+}
+
+resource "aws_security_group_rule" "demo_ai_ingress_from_performance_alb" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_api_alb.id
+  description              = "Demo AI requests from the private performance ALB"
+  security_group_id        = aws_security_group.demo_ai.id
+}
+
+resource "aws_security_group_rule" "demo_ai_egress_to_vpc_endpoints" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpc_endpoints.id
+  description              = "Bedrock, ECR, and CloudWatch through VPC endpoints"
+  security_group_id        = aws_security_group.demo_ai.id
+}
+
+resource "aws_security_group_rule" "demo_ai_egress_to_s3_gateway" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [aws_vpc_endpoint.s3.prefix_list_id]
+  description       = "ECR image layers through S3 Gateway endpoint"
+  security_group_id = aws_security_group.demo_ai.id
+}
+
+# ============================================
 # Performance Runner Security Group
 # ============================================
 resource "aws_security_group" "performance_runner" {
@@ -274,6 +318,7 @@ resource "aws_security_group" "vpc_endpoints" {
     security_groups = [
       aws_security_group.api.id,
       aws_security_group.performance_runner.id,
+      aws_security_group.demo_ai.id,
     ]
   }
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -17,6 +17,24 @@ private_subnet_cidrs = ["10.1.10.0/24", "10.1.20.0/24"]
 # 검증된 backend commit SHA로 바꿔 사용합니다. latest tag는 허용하지 않습니다.
 app_image_tag = "0123456789abcdef0123456789abcdef01234567"
 
+# Image verified in guardbench-demo-ai-service after push.
+demo_ai_image_tag = "d9d9b4a6a36f8f7fe5548d218106dcc500ef4228"
+
+# Approved APAC Nova Micro inference profile and its six routed foundation
+# models. Do not replace these exact ARNs with '*'.
+demo_ai_bedrock_model_id = "apac.amazon.nova-micro-v1:0"
+demo_ai_bedrock_resource_arns = [
+  "arn:aws:bedrock:ap-northeast-2:508139322599:inference-profile/apac.amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-southeast-2::foundation-model/amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-northeast-1::foundation-model/amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-south-1::foundation-model/amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-northeast-2::foundation-model/amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-southeast-1::foundation-model/amazon.nova-micro-v1:0",
+  "arn:aws:bedrock:ap-northeast-3::foundation-model/amazon.nova-micro-v1:0",
+]
+demo_ai_enabled       = false
+demo_ai_desired_count = 1
+
 # The shared dev ECS task can target either the normal dev RDS or the isolated
 # performance-test RDS. Keep dev as the normal deployment default.
 ecs_db_target = "dev"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -95,6 +95,70 @@ variable "app_image_tag" {
   }
 }
 
+variable "demo_ai_image_tag" {
+  description = "Immutable Git SHA tag for the verified Demo AI image"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{7,64}$", var.demo_ai_image_tag))
+    error_message = "demo_ai_image_tag must be a verified Git commit SHA; mutable tags such as latest are not allowed."
+  }
+}
+
+variable "demo_ai_bedrock_model_id" {
+  description = "Bedrock model ID passed to the Demo AI container as BEDROCK_MODEL_ID"
+  type        = string
+
+  validation {
+    condition     = trimspace(var.demo_ai_bedrock_model_id) != ""
+    error_message = "demo_ai_bedrock_model_id must be a non-empty approved Bedrock model ID or inference profile ID."
+  }
+}
+
+variable "demo_ai_bedrock_resource_arns" {
+  description = "Exact Bedrock foundation-model and/or inference-profile ARNs allowed for Demo AI InvokeModel"
+  type        = list(string)
+
+  validation {
+    condition = length(var.demo_ai_bedrock_resource_arns) > 0 && alltrue([
+      for resource_arn in var.demo_ai_bedrock_resource_arns : can(regex(
+        "^arn:(aws|aws-us-gov|aws-cn):bedrock:[a-z0-9-]+:[0-9]{0,12}:(foundation-model|inference-profile)/.+$",
+        resource_arn,
+      ))
+    ])
+    error_message = "demo_ai_bedrock_resource_arns must contain at least one exact Bedrock foundation-model or inference-profile ARN."
+  }
+}
+
+variable "demo_ai_cpu" {
+  description = "CPU units for the Demo AI Fargate task"
+  type        = number
+  default     = 512
+}
+
+variable "demo_ai_memory" {
+  description = "Memory (MiB) for the Demo AI Fargate task"
+  type        = number
+  default     = 1024
+}
+
+variable "demo_ai_desired_count" {
+  description = "Number of Demo AI Fargate tasks used as the performance-test target"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.demo_ai_desired_count >= 0
+    error_message = "demo_ai_desired_count must be zero or greater."
+  }
+}
+
+variable "demo_ai_enabled" {
+  description = "Keep Demo AI tasks running for integrated performance tests"
+  type        = bool
+  default     = false
+}
+
 variable "alarm_email" {
   description = "Optional email address that confirms the dev operations SNS subscription"
   type        = string


### PR DESCRIPTION
## Summary

- Reuse the existing `guardbench-dev-cluster` with a dedicated Demo AI Fargate task definition and service.
- Manage the immutable, scan-on-push `guardbench-demo-ai-service` ECR repository and lifecycle policy.
- Route `/v1/chat/completions` through the existing private `guardbench-dev-performance-api` ALB.
- Keep Demo AI private: private subnets, no public IP, SG-to-SG ingress only, and existing Bedrock Runtime VPC Endpoint access.
- Add a dedicated execution role and task role limited to `bedrock:InvokeModel` on the approved APAC Nova Micro inference profile and six routed foundation-model ARNs.
- Expose `performance_target_url`, `performance_target_model`, and `performance_target_revision` outputs for the Performance Runner.

## Design decisions

1. The existing ECS cluster is reused to avoid introducing another cluster in the dev VPC.
2. Demo AI is a separate task/service from `guardbench-dev-app` so its lifecycle, IAM, logs, and network boundary remain isolated.
3. The existing Runner-only internal ALB is reused with a path rule; its backend default action is unchanged.
4. The path is Performance Runner -> internal ALB -> Demo AI task -> existing Bedrock Runtime VPC Endpoint.
5. The Demo AI task role has only `bedrock:InvokeModel` for the explicitly supplied model resource ARNs. The execution role does not include backend RDS secret access.
6. Terraform owns the Demo AI task definition/service revision for now; automated Demo AI CI/CD is out of scope.

## Deployment notes

- ECR repository `guardbench-demo-ai-service` was bootstrapped separately.
- Image tag `d9d9b4a6a36f8f7fe5548d218106dcc500ef4228` was pushed and verified with digest `sha256:3a75cdbd3cbf49648d5ab2e3213f7cba5aae0ed34d8f26861e9da9701fb9fd43`.
- `demo_ai_enabled` remains false by default; enable it for the performance environment.
- This PR does not run the Performance Runner or a performance test.

## Validation

- `terraform fmt -check`
- `terraform validate`
- Remote-state `terraform plan`: Demo AI resources planned with `0 destroy`; existing cluster/app/ALB resources had no replacement.
