### PR TITLE
fix: align SQS visibility with claim lease

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -52,6 +52,12 @@ terraform apply
 
 성능 테스트용 RDS는 dev RDS와 별도로 생성되며, private subnet에 위치하고 shared dev ECS API security group에서만 PostgreSQL 접근을 허용한다. ECS와 SQS/DLQ는 dev 환경과 공유한다. 따라서 성능 측정 중에는 다른 dev workload가 없어야 하며, 실행 전 Performance Runner가 기존 TestRun과 Source Queue/DLQ 상태를 검증해야 한다.
 
+## SQS visibility와 claim lease
+
+Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP target과 Bedrock provider 호출의 전체 timeout은 각각 15초다. 세 source queue(`gb-run-resolve`, `gb-workitems`, `gb-run-finalize`)는 동일한 shared ECS/SQS topology를 사용하므로 Terraform은 모두 `visibility_timeout_seconds = 90`으로 설정한다. 이 값은 claim lease와 DB phase·스케줄링·ack 처리 여유를 포함해 claim이 유효한 동안 정상 처리 중인 메시지가 다시 노출되지 않도록 한다.
+
+`maxReceiveCount = 5`는 반복되는 malformed message, application/DB 장애를 DLQ로 격리하기 위한 SQS redrive 기준이며 Provider retry budget이 아니다. Provider 호출 재시도는 Backend의 application-level attempt 정책이 소유한다. Performance-test 환경은 별도 queue를 사용하지 않으므로 이 timing 변경은 dev와 performance-test workload 모두에 적용된다.
+
 기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. shared ECS task execution role에는 Dev와 Performance RDS의 두 master secret만 허용해, 전환 중 기존 revision 재시작 또는 circuit breaker rollback도 안전하게 지원한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다. 외부 AI provider를 호출하는 ECS task는 private route table의 NAT Gateway와 API security group의 outbound HTTPS rule을 사용한다. AWS Bedrock 등 VPC Endpoint가 지원하는 서비스는 기존 private endpoint를 우선 사용한다.
 
 전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. Backend의 `performance/build-runner-image.sh`로 이미지를 빌드하고 Terraform output의 전용 ECR repository에 Backend commit SHA tag로 push한 뒤, 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -54,7 +54,7 @@ terraform apply
 
 ## SQS visibility와 claim lease
 
-Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP target과 Bedrock provider 호출의 전체 timeout은 각각 15초다. 세 source queue(`gb-run-resolve`, `gb-workitems`, `gb-run-finalize`)는 동일한 shared ECS/SQS topology를 사용하므로 Terraform은 모두 `visibility_timeout_seconds = 90`으로 설정한다. 이 값은 claim lease와 DB phase·스케줄링·ack 처리 여유를 포함해 claim이 유효한 동안 정상 처리 중인 메시지가 다시 노출되지 않도록 한다.
+Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP target과 Bedrock provider 호출의 전체 timeout은 각각 15초다. 세 source queue(`gb-run-resolve`, `gb-workitems`, `gb-run-finalize`)는 동일한 shared ECS/SQS topology를 사용하므로 Terraform은 모두 `visibility_timeout_seconds = 90`으로 설정한다. Worker가 `ReceiveMessage`마다 visibility를 명시하므로 Backend의 `guardbench.sqs.polling.visibility-timeout-seconds`도 90초여야 실제 메시지 visibility가 이 계약을 따른다. 따라서 Terraform apply만으로는 충분하지 않으며, Backend runtime companion PR [#159](https://github.com/GuardBench/guardbench-backend/pull/159)도 함께 반영해야 한다. 두 값은 claim lease와 DB phase·스케줄링·ack 처리 여유를 포함해 claim이 유효한 동안 정상 처리 중인 메시지가 다시 노출되지 않도록 한다.
 
 `maxReceiveCount = 5`는 반복되는 malformed message, application/DB 장애를 DLQ로 격리하기 위한 SQS redrive 기준이며 Provider retry budget이 아니다. Provider 호출 재시도는 Backend의 application-level attempt 정책이 소유한다. Performance-test 환경은 별도 queue를 사용하지 않으므로 이 timing 변경은 dev와 performance-test workload 모두에 적용된다.
 

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -4,6 +4,20 @@ locals {
     "gb-workitems",
     "gb-run-finalize",
   ])
+
+  # Backend dev defaults: the execution/resolution claim lease is 45s. Keep
+  # enough time after the lease window for DB phase work, scheduling delay,
+  # and SQS acknowledgement before a message can be delivered again.
+  claim_lease_seconds        = 45
+  processing_buffer_seconds  = 15
+  visibility_timeout_seconds = 90
+}
+
+check "sqs_visibility_timeout_contract" {
+  assert {
+    condition     = local.visibility_timeout_seconds > local.claim_lease_seconds + local.processing_buffer_seconds
+    error_message = "SQS visibility timeout must exceed the 45s claim lease and processing buffer."
+  }
 }
 
 resource "aws_sqs_queue" "dead_letter" {
@@ -21,7 +35,7 @@ resource "aws_sqs_queue" "source" {
   for_each = local.queue_names
 
   name                       = "${var.project}-${var.environment}-${each.value}"
-  visibility_timeout_seconds = 30
+  visibility_timeout_seconds = local.visibility_timeout_seconds
   receive_wait_time_seconds  = 20
 
   redrive_policy = jsonencode({


### PR DESCRIPTION
## Summary

- Align all three shared dev source queues with the Backend timing contract by increasing SQS queue visibility timeout from 30s to 90s.
- Add a Terraform check for the 45s claim lease plus processing buffer contract.
- Document that performance-test uses the same queues and that `maxReceiveCount = 5` remains an SQS/DLQ redrive threshold, not a Provider retry budget.
- Require Backend runtime companion PR [#159](https://github.com/GuardBench/guardbench-backend/pull/159), which aligns the per-receive `ReceiveMessage` visibility override to 90s.

The IaC queue default and Backend runtime override must both be 90s; merging/applying this PR alone does not complete the timing contract.

## Validation

- `terraform fmt -check terraform`
- `terraform validate`
- Targeted Terraform plan: `0 to add, 3 to change, 0 to destroy`
- AWS read-only check: all three source queues were at 30s with unchanged `maxReceiveCount = 5` redrive policies.

The full plan also reports pre-existing unrelated drift from the current remote state; this PR does not address or apply that drift.

Refs: #24
