### PR TITLE
fix(alb): Backend health check를 /health로 전환

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -31,7 +31,7 @@ resource "aws_lb_target_group" "api" {
 
   health_check {
     enabled             = true
-    path                = "/api/v1/test-suites"
+    path                = "/health"
     port                = "traffic-port"
     protocol            = "HTTP"
     healthy_threshold   = 2

--- a/terraform/performance-api-alb.tf
+++ b/terraform/performance-api-alb.tf
@@ -62,7 +62,7 @@ resource "aws_lb_target_group" "performance_api" {
   vpc_id      = aws_vpc.main.id
 
   health_check {
-    path                = "/api/v1/test-suites"
+    path                = "/health"
     healthy_threshold   = 2
     unhealthy_threshold = 3
     timeout             = 5


### PR DESCRIPTION
## 관련 Issue

Closes #26

## 결과

- public API Target Group의 ALB health check path를 /api/v1/test-suites에서 /health로 변경했습니다.
- performance internal API Target Group의 health check path도 /health로 변경했습니다.
- 두 Target Group의 HTTP 200 matcher는 유지했습니다.
- Demo AI Target Group, listener/routing, security group 규칙은 변경하지 않았습니다.

## 변경 범위

- terraform/alb.tf
- terraform/performance-api-alb.tf

## 계약과 호환성 영향

- Backend #160의 DB-independent GET /health endpoint를 전제로 하는 운영 설정 변경입니다.
- DB, ECS task definition, listener routing, security group, dependency 변경은 없습니다.
- Terraform remote state plan에서 이번 두 Target Group은 in-place update로 계획되었습니다.
- plan 전체에는 기존 state와 origin/dev 구성 사이의 pre-existing drift가 함께 나타났으며, 0 destroy입니다. 해당 drift는 이 PR에 포함하지 않았습니다.

## 검증

| 명령 또는 확인 | 결과 |
| --- | --- |
| terraform fmt -check | PASS |
| terraform validate | PASS |
| remote-state terraform plan | PASS: 0 destroy; 대상 TG 2개 in-place update |
| git diff --check | PASS |

미검증 항목:

- apply 후 두 ALB Target Group의 /health healthy 상태와 Backend ECS services-stable 도달 여부는 PR merge 및 배포 후 확인이 필요합니다.
- apply는 실행하지 않았습니다.

## 커밋

- 5010cac fix(alb): use backend health endpoint for API target groups