### PR TITLE
feat(terraform): parameterize backend service capacity

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,6 +25,34 @@ terraform import aws_lb.main arn:aws:elasticloadbalancing:...
 terraform import aws_cloudfront_distribution.frontend DISTRIBUTION_ID
 ```
 
+## Backend ECS capacity 실험
+
+Backend ECS task 수는 `backend_service_desired_counts` 한 곳에서 서비스 역할별로 관리한다. 현재는 API와 worker가 `guardbench-dev-app` 하나의 결합 서비스에서 실행되므로 `app` 값이 해당 서비스의 `desired_count`를 제어한다. API/worker 서비스가 분리되면 같은 입력에 `api`와 `worker` 값을 추가하고 각 서비스가 해당 키를 사용하도록 확장한다. 이 작업은 역할별 최적 task 수를 결정하지 않는다.
+
+성능 테스트에서 결합된 현재 서비스를 2개로 바꾸려면 `terraform.tfvars`의 입력만 변경한다.
+
+```hcl
+backend_service_desired_counts = {
+  app = 2
+}
+```
+
+역할 분리 이후에는 다음처럼 각 서비스의 capacity 조합을 반복해서 측정할 수 있다.
+
+```hcl
+backend_service_desired_counts = {
+  api    = 2
+  worker = 4
+}
+```
+
+```bash
+terraform plan -var='backend_service_desired_counts={app=2}'
+terraform apply
+```
+
+현재 결합 서비스의 `app` 값 변경은 `aws_ecs_service.app`의 `desired_count`만 갱신하며 task definition이나 다른 서비스의 capacity를 변경하지 않는다. `terraform plan`에서 이 변경이 의도한 ECS Service update인지 확인한 뒤 apply한다.
+
 ## 배포 순서
 
 ```bash

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,6 +1,14 @@
 data "aws_caller_identity" "current" {}
 
 locals {
+  # Keep all backend service capacity inputs in one map. The app service is
+  # currently the combined API/worker service; api and worker can be consumed
+  # by their respective resources when the backend is split.
+  backend_service_desired_counts = merge(
+    { app = 1 },
+    var.backend_service_desired_counts,
+  )
+
   selected_db = var.ecs_db_target == "performance" ? {
     address           = aws_db_instance.performance.address
     master_secret_arn = aws_db_instance.performance.master_user_secret[0].secret_arn
@@ -167,7 +175,7 @@ resource "aws_ecs_service" "app" {
   name            = "${var.project}-${var.environment}-app"
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.app.arn
-  desired_count   = var.app_desired_count
+  desired_count   = local.backend_service_desired_counts["app"]
   launch_type     = "FARGATE"
 
   # GitHub Actions owns application task-definition revisions after the

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -14,6 +14,15 @@ vpc_cidr             = "10.1.0.0/16"
 public_subnet_cidrs  = ["10.1.1.0/24", "10.1.2.0/24"]
 private_subnet_cidrs = ["10.1.10.0/24", "10.1.20.0/24"]
 
+# Backend ECS service capacity. The current app service runs API and worker
+# together. Add independent api/worker values when those services are split;
+# the same input block can then be reused for performance experiments.
+backend_service_desired_counts = {
+  app = 1
+  # api    = 2
+  # worker = 1
+}
+
 # 검증된 backend commit SHA로 바꿔 사용합니다. latest tag는 허용하지 않습니다.
 app_image_tag = "0123456789abcdef0123456789abcdef01234567"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,10 +79,18 @@ variable "api_memory" {
   default     = 1024
 }
 
-variable "app_desired_count" {
-  description = "Number of combined application tasks"
-  type        = number
-  default     = 1
+variable "backend_service_desired_counts" {
+  description = "Desired task counts keyed by backend ECS service role; app is the current combined service and api/worker are available for the future split"
+  type        = map(number)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for desired_count in values(var.backend_service_desired_counts) :
+      desired_count >= 0 && desired_count == floor(desired_count)
+    ])
+    error_message = "backend_service_desired_counts values must be non-negative whole numbers."
+  }
 }
 
 variable "app_image_tag" {


### PR DESCRIPTION
## Summary
- parameterize backend ECS desired counts with a role-keyed input map
- keep the current combined app service on the app capacity key
- document future api/worker capacity experiments and plan/apply workflow

## Validation
- terraform fmt -check -diff
- terraform validate
- git diff --check
- remote-state targeted plan with backend_service_desired_counts.app=2:
  - aws_ecs_service.app desired_count: 1 -> 2
  - Plan: 0 to add, 1 to change, 0 to destroy

The full remote-state plan also reported two pre-existing, out-of-scope drifts (CloudFront enabled false -> true and frontend IAM policy update), resulting in 0 to add, 3 to change, 0 to destroy. The ECS-targeted plan confirms this PR changes only the intended service capacity.

Closes #28