### PR TITLE
feat(terraform): support private RDS access and concurrent dev/perf workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+# AWS CLI login cache (temporary credentials; never commit)
+.aws-login-cache/
+.aws-login-/
+
+# Local Terraform plan artifacts
+tfplan
+*.tfplan
+
 # IDE
 .idea/
 .vscode/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -61,7 +61,7 @@ terraform validate
 terraform plan -out=tfplan
 ```
 
-계획에서 기존 네트워크, NAT Gateway/EIP, S3, CloudFront, ALB, Target Group의 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 NAT 기반 private-subnet 외부 HTTPS egress, ECR·RDS·SQS·Secrets Manager Endpoint·단일 ECS App Service·CloudWatch/SNS를 생성하거나 갱신한다. Terraform apply 자체는 Backend application 재배포를 의미하지 않는다.
+계획에서 기존 네트워크, NAT Gateway/EIP, S3, CloudFront, ALB, Target Group, Dev RDS의 불필요한 삭제 또는 교체가 없음을 사람이 확인한 뒤에만 `terraform apply tfplan`을 실행한다. apply는 NAT 기반 private-subnet 외부 HTTPS egress, ECR·RDS·SQS·Secrets Manager Endpoint·Dev/선택적 Performance ECS Service·SSM RDS access host·CloudWatch/SNS를 생성하거나 갱신한다. Terraform apply 자체는 Backend application image 배포를 의미하지 않는다.
 
 Bootstrap 시 ECR image는 Terraform apply 전에 push한다. Task Definition은 `latest`가 아닌 immutable commit SHA tag만 받는다. 이후 Backend application 배포는 `app_image_tag` 변경이 아니라 Backend GitHub Actions로 수행한다. `alarm_email`을 설정하면 SNS email subscription이 생성되며 수신자가 AWS confirmation 메일을 승인해야 한다.
 
@@ -78,21 +78,54 @@ terraform apply
 
 ## Performance RDS 운영 전제
 
-성능 테스트용 RDS는 dev RDS와 별도로 생성되며, private subnet에 위치하고 shared dev ECS API security group에서만 PostgreSQL 접근을 허용한다. ECS와 SQS/DLQ는 dev 환경과 공유한다. 따라서 성능 측정 중에는 다른 dev workload가 없어야 하며, 실행 전 Performance Runner가 기존 TestRun과 Source Queue/DLQ 상태를 검증해야 한다.
+성능 테스트용 RDS는 dev RDS와 별도로 생성되며, private subnet에 위치하고 Dev Backend SG, Performance Backend SG, Performance Runner SG, SSM RDS access host SG에서만 PostgreSQL 접근을 허용한다. ECS cluster는 dev와 공유하지만 Dev/Performance Backend ECS service와 각각의 SQS/DLQ 집합은 분리한다. Performance service는 기본적으로 0 task이며, 동시 실행이 필요할 때만 별도로 활성화한다. 실행 전 Performance Runner가 기존 TestRun과 performance Source Queue/DLQ 상태를 검증해야 한다.
 
 ## SQS visibility와 claim lease
 
-Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP target과 Bedrock provider 호출의 전체 timeout은 각각 15초다. 세 source queue(`gb-run-resolve`, `gb-workitems`, `gb-run-finalize`)는 동일한 shared ECS/SQS topology를 사용하므로 Terraform은 모두 `visibility_timeout_seconds = 90`으로 설정한다. Worker가 `ReceiveMessage`마다 visibility를 명시하므로 Backend의 `guardbench.sqs.polling.visibility-timeout-seconds`도 90초여야 실제 메시지 visibility가 이 계약을 따른다. 따라서 Terraform apply만으로는 충분하지 않으며, Backend runtime companion PR [#159](https://github.com/GuardBench/guardbench-backend/pull/159)도 함께 반영해야 한다. 두 값은 claim lease와 DB phase·스케줄링·ack 처리 여유를 포함해 claim이 유효한 동안 정상 처리 중인 메시지가 다시 노출되지 않도록 한다.
+Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP target과 Bedrock provider 호출의 전체 timeout은 각각 15초다. Dev와 Performance service는 각각 세 개의 독립 source queue(`gb-run-resolve`, `gb-workitems`, `gb-run-finalize`)를 사용하고 Terraform은 모두 `visibility_timeout_seconds = 90`으로 설정한다. Worker가 `ReceiveMessage`마다 visibility를 명시하므로 Backend의 `guardbench.sqs.polling.visibility-timeout-seconds`도 90초여야 실제 메시지 visibility가 이 계약을 따른다. 따라서 Terraform apply만으로는 충분하지 않으며, Backend runtime companion PR [#159](https://github.com/GuardBench/guardbench-backend/pull/159)도 함께 반영해야 한다. 두 값은 claim lease와 DB phase·스케줄링·ack 처리 여유를 포함해 claim이 유효한 동안 정상 처리 중인 메시지가 다시 노출되지 않도록 한다.
 
-`maxReceiveCount = 5`는 반복되는 malformed message, application/DB 장애를 DLQ로 격리하기 위한 SQS redrive 기준이며 Provider retry budget이 아니다. Provider 호출 재시도는 Backend의 application-level attempt 정책이 소유한다. Performance-test 환경은 별도 queue를 사용하지 않으므로 이 timing 변경은 dev와 performance-test workload 모두에 적용된다.
+`maxReceiveCount = 5`는 반복되는 malformed message, application/DB 장애를 DLQ로 격리하기 위한 SQS redrive 기준이며 Provider retry budget이 아니다. Provider 호출 재시도는 Backend의 application-level attempt 정책이 소유한다. Dev와 performance-test는 별도 source queue/DLQ를 사용하지만 visibility timeout 계약은 동일하게 적용된다.
 
-기본값인 `ecs_db_target = "dev"`는 기존 dev RDS를 사용한다. 성능 테스트를 위해서는 `ecs_db_target = "performance"`으로 Terraform apply하여 JDBC endpoint와 Secrets Manager username/password가 모두 Performance RDS를 참조하는 baseline Task Definition을 등록한다. 이후 Backend issue #142가 적용된 Backend GitHub Actions deploy를 실행해 latest ACTIVE revision을 기반으로 ECS Service에 반영한다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. shared ECS task execution role에는 Dev와 Performance RDS의 두 master secret만 허용해, 전환 중 기존 revision 재시작 또는 circuit breaker rollback도 안전하게 지원한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다. 외부 AI provider를 호출하는 ECS task는 private route table의 NAT Gateway와 API security group의 outbound HTTPS rule을 사용한다. AWS Bedrock 등 VPC Endpoint가 지원하는 서비스는 기존 private endpoint를 우선 사용한다.
+Dev Backend는 Dev RDS와 Dev queue를 고정으로 사용하고, Performance Backend는 Performance RDS와 Performance queue를 고정으로 사용한다. `ecs_db_target`은 기존 `terraform.tfvars` 호환을 위해 남아 있지만 더 이상 리소스 선택에 사용하지 않는다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. Dev/Performance service는 shared ECS task execution/app task role을 사용하며 두 RDS secret과 두 queue 집합에 필요한 권한만 허용한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다. 외부 AI provider를 호출하는 ECS task는 private route table의 NAT Gateway와 API security group의 outbound HTTPS rule을 사용한다. AWS Bedrock 등 VPC Endpoint가 지원하는 서비스는 기존 private endpoint를 우선 사용한다.
 
 전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. Backend의 `performance/build-runner-image.sh`로 이미지를 빌드하고 Terraform output의 전용 ECR repository에 Backend commit SHA tag로 push한 뒤, 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
 
-## Demo AI 성능 테스트 Target
+## Private RDS 개발자 접근
 
-Demo AI는 기존 `guardbench-dev-cluster`를 재사용하는 별도 Fargate Task Definition/Service다. Backend `guardbench-dev-app`의 sidecar가 아니며, 전용 task role·execution role·CloudWatch Log Group·security group을 사용한다. Demo AI image는 `guardbench-demo-ai-service` 전용 ECR repository의 immutable Git SHA tag로 지정한다. 기존 `performance_runner_enabled` 패턴에 맞춰 `demo_ai_enabled = false`가 기본값이며, 성능 테스트 시 `true`로 켜고 종료 후 다시 끌 수 있다.
+RDS는 계속 private 상태로 유지한다. Terraform이 생성하는 SSM-managed access host는 private subnet에 배치되고 public IP, SSH inbound, database credential을 갖지 않는다. AWS Systems Manager Session Manager의 remote-host port forwarding을 사용해 로컬 psql 또는 DBeaver에서 Dev/Performance RDS에 연결한다. 로컬 환경에는 AWS CLI와 Session Manager plugin이 필요하다.
+
+```bash
+access_host="$(terraform output -raw db_access_host_instance_id)"
+dev_rds="$(terraform output -raw rds_endpoint)"
+
+aws ssm start-session \
+  --target "$access_host" \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters "{\"host\":[\"$dev_rds\"],\"portNumber\":[\"5432\"],\"localPortNumber\":[\"15432\"]}"
+```
+
+Performance RDS는 같은 명령에서 `performance_rds_endpoint` output과 다른 local port(예: `15433`)를 사용한다. PostgreSQL username/password는 RDS가 관리하는 Secrets Manager secret에서 확인하며 Terraform output이나 task definition에 출력하지 않는다.
+
+## Dev/Performance 동시 실행
+
+Dev Backend service(`guardbench-dev-app`)는 public ALB와 Dev RDS/queue를 사용한다. Performance Backend service(`guardbench-dev-performance-app`)는 performance internal ALB와 Performance RDS/queue를 사용한다. Performance service를 켜려면 다음 변수를 설정한다.
+
+```hcl
+performance_app_enabled       = true
+performance_app_desired_count = 1
+performance_runner_enabled    = true
+```
+
+이제 Performance 실행을 위해 `ecs_db_target`을 바꾸거나 Dev service를 재배포할 필요가 없다. Performance service의 task definition은 Terraform이 관리하고, 기존 Dev service의 task definition revision은 Backend GitHub Actions가 계속 관리한다. 구조 변경을 적용한 뒤에는 Dev Backend deploy workflow를 한 번 실행해 Dev service가 Dev RDS/queue 환경변수를 가진 최신 revision을 사용하도록 확인한다. 이 일회성 migration 전에는 기존 shared service가 Performance baseline revision을 계속 가리킬 수 있으므로, 새 baseline을 등록한 뒤 Dev deploy를 완료하고 Performance service를 켠다.
+
+```bash
+terraform output -raw ecs_task_definition_arn
+terraform output -raw performance_ecs_service_name
+```
+
+## Demo AI dev/성능 테스트 Target
+
+Demo AI는 기존 `guardbench-dev-cluster`를 재사용하는 별도 Fargate Task Definition/Service다. Backend `guardbench-dev-app` 또는 `guardbench-dev-performance-app`의 sidecar가 아니며, 전용 task role·execution role·CloudWatch Log Group·security group을 사용한다. Demo AI image는 `guardbench-demo-ai-service` 전용 ECR repository의 immutable Git SHA tag로 지정한다. dev에서 통합 target으로 사용하므로 예제 설정은 `demo_ai_enabled = true`이며, 비용 절감이나 일시 중지가 필요할 때만 `false`로 바꾼다.
 
 기존 `guardbench-dev-performance-api` internal ALB를 재사용하고 `/v1/chat/completions` path rule만 Demo AI target group으로 전달한다. 기존 ALB default action과 Backend target group은 변경하지 않는다. ALB health check는 Demo AI의 `GET /health`를 사용한다. Runner SG에서 internal ALB SG로 HTTP 80, ALB SG에서 Demo AI task SG로 TCP 8080만 허용되며, Demo AI task는 private subnet에서 `assign_public_ip = false`로 실행된다.
 

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -13,6 +13,12 @@ resource "aws_lb" "main" {
 
   enable_deletion_protection = var.environment == "prod" ? true : false
 
+  access_logs {
+    bucket  = aws_s3_bucket.alb_access_logs.id
+    enabled = true
+    prefix  = "public"
+  }
+
   tags = {
     Name = "${var.project}-${var.environment}-alb"
   }

--- a/terraform/cloudfront-s3.tf
+++ b/terraform/cloudfront-s3.tf
@@ -99,7 +99,8 @@ resource "aws_cloudfront_function" "spa_rewrite" {
 
 # --- CloudFront Distribution ---
 resource "aws_cloudfront_distribution" "frontend" {
-  enabled             = true
+  # Keep the distribution disabled until the frontend is ready for manual activation.
+  enabled             = false
   is_ipv6_enabled     = true
   default_root_object = var.spa_index_document
   comment             = "GuardBench ${var.environment} frontend"

--- a/terraform/db-access.tf
+++ b/terraform/db-access.tf
@@ -1,0 +1,146 @@
+# Private SSM access host for developer-to-RDS port forwarding.
+# The host has no public IP or inbound rule; all operator access goes through
+# AWS Systems Manager Session Manager and the existing private endpoints.
+
+data "aws_ssm_parameter" "db_access_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+resource "aws_security_group" "db_access" {
+  name        = "${var.project}-${var.environment}-db-access-sg"
+  description = "SSM-only private host for RDS port forwarding"
+  vpc_id      = aws_vpc.main.id
+  ingress     = []
+  egress      = []
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-db-access-sg"
+    Purpose = "rds-access"
+  }
+}
+
+resource "aws_security_group_rule" "db_access_egress_to_rds" {
+  type                     = "egress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds.id
+  description              = "Port forwarding to development RDS"
+  security_group_id        = aws_security_group.db_access.id
+}
+
+resource "aws_security_group_rule" "db_access_egress_to_performance_rds" {
+  type                     = "egress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_rds.id
+  description              = "Port forwarding to performance RDS"
+  security_group_id        = aws_security_group.db_access.id
+}
+
+resource "aws_security_group_rule" "db_access_egress_to_vpc_endpoints" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.vpc_endpoints.id
+  description              = "SSM APIs through VPC endpoints"
+  security_group_id        = aws_security_group.db_access.id
+}
+
+resource "aws_security_group_rule" "rds_ingress_from_db_access" {
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.db_access.id
+  description              = "Developer access through SSM port forwarding"
+  security_group_id        = aws_security_group.rds.id
+}
+
+resource "aws_security_group_rule" "performance_rds_ingress_from_db_access" {
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.db_access.id
+  description              = "Developer access through SSM port forwarding"
+  security_group_id        = aws_security_group.performance_rds.id
+}
+
+resource "aws_security_group_rule" "vpc_endpoints_ingress_from_db_access" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.db_access.id
+  description              = "SSM access host HTTPS"
+  security_group_id        = aws_security_group.vpc_endpoints.id
+}
+
+resource "aws_iam_role" "db_access" {
+  name = "${var.project}-${var.environment}-db-access-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-db-access-role"
+    Purpose = "rds-access"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "db_access_ssm" {
+  role       = aws_iam_role.db_access.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "db_access" {
+  name = "${var.project}-${var.environment}-db-access-profile"
+  role = aws_iam_role.db_access.name
+}
+
+resource "aws_instance" "db_access" {
+  count                       = var.db_access_host_enabled ? 1 : 0
+  ami                         = data.aws_ssm_parameter.db_access_ami.value
+  instance_type               = var.db_access_host_instance_type
+  subnet_id                   = aws_subnet.private[0].id
+  vpc_security_group_ids      = [aws_security_group.db_access.id]
+  iam_instance_profile        = aws_iam_instance_profile.db_access.name
+  associate_public_ip_address = false
+
+  user_data = <<-USERDATA
+    #!/bin/bash
+    set -euo pipefail
+    systemctl enable --now amazon-ssm-agent || true
+  USERDATA
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 8
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-db-access"
+    Purpose = "rds-access"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.db_access_ssm,
+    aws_security_group_rule.db_access_egress_to_vpc_endpoints,
+    aws_security_group_rule.vpc_endpoints_ingress_from_db_access,
+  ]
+}

--- a/terraform/demo-ai.tf
+++ b/terraform/demo-ai.tf
@@ -64,12 +64,25 @@ resource "aws_iam_role_policy" "demo_ai_task" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid      = "InvokeApprovedBedrockModels"
-      Effect   = "Allow"
-      Action   = ["bedrock:InvokeModel"]
-      Resource = var.demo_ai_bedrock_resource_arns
-    }]
+    Statement = [
+      {
+        Sid      = "InvokeApprovedBedrockModels"
+        Effect   = "Allow"
+        Action   = ["bedrock:InvokeModel"]
+        Resource = var.demo_ai_bedrock_resource_arns
+      },
+      {
+        Sid    = "EcsExecMessageChannels"
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Resource = "*"
+      },
+    ]
   })
 }
 
@@ -115,11 +128,12 @@ resource "aws_ecs_task_definition" "demo_ai" {
 }
 
 resource "aws_ecs_service" "demo_ai" {
-  name            = "${var.project}-${var.environment}-demo-ai"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.demo_ai.arn
-  desired_count   = var.demo_ai_enabled ? var.demo_ai_desired_count : 0
-  launch_type     = "FARGATE"
+  name                   = "${var.project}-${var.environment}-demo-ai"
+  cluster                = aws_ecs_cluster.main.id
+  task_definition        = aws_ecs_task_definition.demo_ai.arn
+  desired_count          = var.demo_ai_enabled ? var.demo_ai_desired_count : 0
+  launch_type            = "FARGATE"
+  enable_execute_command = true
 
   network_configuration {
     subnets          = aws_subnet.private[*].id

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -9,15 +9,67 @@ locals {
     var.backend_service_desired_counts,
   )
 
-  selected_db = var.ecs_db_target == "performance" ? {
-    address           = aws_db_instance.performance.address
-    master_secret_arn = aws_db_instance.performance.master_user_secret[0].secret_arn
-    database_name     = "guardbench_perf"
-    } : {
-    address           = aws_db_instance.app.address
-    master_secret_arn = aws_db_instance.app.master_user_secret[0].secret_arn
-    database_name     = "guardbench"
+  backend_container_base = {
+    name      = "app"
+    image     = "${aws_ecr_repository.app.repository_url}:${var.app_image_tag}"
+    essential = true
+
+    portMappings = [{
+      containerPort = var.api_container_port
+      protocol      = "tcp"
+    }]
   }
+
+  backend_common_environment = [
+    { name = "SERVER_PORT", value = tostring(var.api_container_port) },
+    { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
+    { name = "AWS_REGION", value = var.aws_region },
+    { name = "SQS_ENABLED", value = "true" },
+    { name = "WORKER_ENABLED", value = "true" },
+    { name = "SPRING_TASK_SCHEDULING_POOL_SIZE", value = "4" },
+  ]
+
+  backend_dev_container = merge(local.backend_container_base, {
+    environment = concat(local.backend_common_environment, [
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${aws_db_instance.app.address}:${var.db_port}/guardbench?sslmode=require" },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RESOLVE", value = aws_sqs_queue.source["gb-run-resolve"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_WORK_ITEMS", value = aws_sqs_queue.source["gb-workitems"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RUN_FINALIZE", value = aws_sqs_queue.source["gb-run-finalize"].url },
+    ])
+    secrets = [
+      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:username::" },
+      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${aws_db_instance.app.master_user_secret[0].secret_arn}:password::" },
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.app.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "app"
+      }
+    }
+  })
+
+  backend_performance_container = merge(local.backend_container_base, {
+    environment = concat(local.backend_common_environment, [
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${aws_db_instance.performance.address}:${var.db_port}/guardbench_perf?sslmode=require" },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RESOLVE", value = aws_sqs_queue.performance_source["gb-run-resolve"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_WORK_ITEMS", value = aws_sqs_queue.performance_source["gb-workitems"].url },
+      { name = "GUARDBENCH_SQS_QUEUE_URLS_RUN_FINALIZE", value = aws_sqs_queue.performance_source["gb-run-finalize"].url },
+    ])
+    secrets = [
+      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${aws_db_instance.performance.master_user_secret[0].secret_arn}:username::" },
+      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${aws_db_instance.performance.master_user_secret[0].secret_arn}:password::" },
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.performance_app.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "performance-app"
+      }
+    }
+  })
 }
 
 resource "aws_ecs_cluster" "main" {
@@ -36,6 +88,16 @@ resource "aws_ecs_cluster" "main" {
 resource "aws_cloudwatch_log_group" "app" {
   name              = "/ecs/${var.project}-${var.environment}/app"
   retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_group" "performance_app" {
+  name              = "/ecs/${var.project}-${var.environment}/performance-app"
+  retention_in_days = 14
+
+  tags = {
+    Name    = "/ecs/${var.project}-${var.environment}/performance-app"
+    Purpose = "performance-testing"
+  }
 }
 
 resource "aws_iam_role" "ecs_task_execution" {
@@ -65,9 +127,8 @@ resource "aws_iam_role_policy" "ecs_exec_secrets" {
     Statement = [{
       Effect = "Allow"
       Action = ["secretsmanager:GetSecretValue"]
-      # The service and circuit breaker can still start a task from either
-      # Task Definition revision while a DB target switch is being deployed.
-      # Keep both intended RDS secrets available to the shared execution role.
+      # Dev and performance services use separate task definitions but share
+      # the execution role. Keep both intended RDS secrets available.
       Resource = [
         aws_db_instance.app.master_user_secret[0].secret_arn,
         aws_db_instance.performance.master_user_secret[0].secret_arn,
@@ -103,7 +164,10 @@ resource "aws_iam_role_policy" "app_task" {
           "sqs:ReceiveMessage",
           "sqs:DeleteMessage",
         ]
-        Resource = values(aws_sqs_queue.source)[*].arn
+        Resource = concat(
+          [for queue in values(aws_sqs_queue.source) : queue.arn],
+          [for queue in values(aws_sqs_queue.performance_source) : queue.arn],
+        )
       },
       {
         Effect = "Allow"
@@ -112,6 +176,16 @@ resource "aws_iam_role_policy" "app_task" {
           "bedrock:ApplyGuardrail",
         ]
         Resource = "arn:aws:bedrock:${var.aws_region}:${data.aws_caller_identity.current.account_id}:guardrail/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Resource = "*"
       },
     ]
   })
@@ -132,53 +206,42 @@ resource "aws_ecs_task_definition" "app" {
   execution_role_arn = aws_iam_role.ecs_task_execution.arn
   task_role_arn      = aws_iam_role.app_task.arn
 
-  container_definitions = jsonencode([{
-    name      = "app"
-    image     = "${aws_ecr_repository.app.repository_url}:${var.app_image_tag}"
-    essential = true
+  container_definitions = jsonencode([local.backend_dev_container])
+}
 
-    portMappings = [{
-      containerPort = var.api_container_port
-      protocol      = "tcp"
-    }]
+resource "aws_ecs_task_definition" "performance_app" {
+  family                   = "${var.project}-${var.environment}-performance-app"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.api_cpu
+  memory                   = var.api_memory
 
-    environment = [
-      { name = "SERVER_PORT", value = tostring(var.api_container_port) },
-      { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
-      { name = "SPRING_DATASOURCE_URL", value = "jdbc:postgresql://${local.selected_db.address}:${var.db_port}/${local.selected_db.database_name}?sslmode=require" },
-      { name = "AWS_REGION", value = var.aws_region },
-      { name = "SQS_ENABLED", value = "true" },
-      { name = "WORKER_ENABLED", value = "true" },
-      { name = "SPRING_TASK_SCHEDULING_POOL_SIZE", value = "4" },
-      { name = "GUARDBENCH_SQS_QUEUE_URLS_RESOLVE", value = aws_sqs_queue.source["gb-run-resolve"].url },
-      { name = "GUARDBENCH_SQS_QUEUE_URLS_WORK_ITEMS", value = aws_sqs_queue.source["gb-workitems"].url },
-      { name = "GUARDBENCH_SQS_QUEUE_URLS_RUN_FINALIZE", value = aws_sqs_queue.source["gb-run-finalize"].url },
-    ]
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
 
-    secrets = [
-      { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${local.selected_db.master_secret_arn}:username::" },
-      { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = "${local.selected_db.master_secret_arn}:password::" },
-    ]
+  execution_role_arn = aws_iam_role.ecs_task_execution.arn
+  task_role_arn      = aws_iam_role.app_task.arn
 
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        "awslogs-group"         = aws_cloudwatch_log_group.app.name
-        "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "app"
-      }
-    }
-  }])
+  container_definitions = jsonencode([local.backend_performance_container])
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-performance-app"
+    Purpose = "performance-testing"
+  }
 }
 
 resource "aws_ecs_service" "app" {
-  name            = "${var.project}-${var.environment}-app"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.app.arn
-  desired_count   = local.backend_service_desired_counts["app"]
-  launch_type     = "FARGATE"
+  name                              = "${var.project}-${var.environment}-app"
+  cluster                           = aws_ecs_cluster.main.id
+  task_definition                   = aws_ecs_task_definition.app.arn
+  desired_count                     = local.backend_service_desired_counts["app"]
+  launch_type                       = "FARGATE"
+  health_check_grace_period_seconds = 120
+  enable_execute_command            = true
 
-  # GitHub Actions owns application task-definition revisions after the
+  # GitHub Actions owns dev application task-definition revisions after the
   # initial service creation. Terraform continues to own the service shape
   # but must not roll the service back to its baseline revision.
   lifecycle {
@@ -197,6 +260,32 @@ resource "aws_ecs_service" "app" {
     container_port   = var.api_container_port
   }
 
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  depends_on = [aws_lb_listener.http]
+}
+
+resource "aws_ecs_service" "performance_app" {
+  name                              = "${var.project}-${var.environment}-performance-app"
+  cluster                           = aws_ecs_cluster.main.id
+  task_definition                   = aws_ecs_task_definition.performance_app.arn
+  desired_count                     = var.performance_app_enabled ? var.performance_app_desired_count : 0
+  launch_type                       = "FARGATE"
+  health_check_grace_period_seconds = 120
+  enable_execute_command            = true
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.api.id]
+    assign_public_ip = false
+  }
+
   load_balancer {
     target_group_arn = aws_lb_target_group.performance_api.arn
     container_name   = "app"
@@ -211,5 +300,7 @@ resource "aws_ecs_service" "app" {
     rollback = true
   }
 
-  depends_on = [aws_lb_listener.http, aws_lb_listener.performance_api]
+  # The existing shared service must detach from this target group before the
+  # dedicated performance service registers its own tasks.
+  depends_on = [aws_ecs_service.app, aws_lb_listener.performance_api]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -96,8 +96,23 @@ output "performance_runner_api_url" {
 }
 
 output "ecs_service_name" {
-  description = "Combined application ECS service name for performance-run automation"
+  description = "Development application ECS service name"
   value       = aws_ecs_service.app.name
+}
+
+output "ecs_task_definition_arn" {
+  description = "Development application Terraform-managed baseline task definition ARN"
+  value       = aws_ecs_task_definition.app.arn
+}
+
+output "performance_ecs_service_name" {
+  description = "Dedicated performance application ECS service name"
+  value       = aws_ecs_service.performance_app.name
+}
+
+output "performance_ecs_task_definition_family" {
+  description = "Dedicated performance application ECS task definition family"
+  value       = aws_ecs_task_definition.performance_app.family
 }
 
 output "ecr_repository_url" {
@@ -106,8 +121,13 @@ output "ecr_repository_url" {
 }
 
 output "rds_endpoint" {
-  description = "Private PostgreSQL endpoint for the combined app service"
+  description = "Private PostgreSQL endpoint for the development app service"
   value       = aws_db_instance.app.address
+}
+
+output "rds_master_secret_arn" {
+  description = "Secrets Manager ARN for the development RDS credentials"
+  value       = aws_db_instance.app.master_user_secret[0].secret_arn
 }
 
 output "performance_rds_endpoint" {
@@ -123,6 +143,16 @@ output "performance_rds_identifier" {
 output "performance_rds_master_secret_arn" {
   description = "Secrets Manager ARN for the isolated performance RDS credentials"
   value       = aws_db_instance.performance.master_user_secret[0].secret_arn
+}
+
+output "db_access_host_instance_id" {
+  description = "Private SSM-managed EC2 instance ID for RDS port forwarding"
+  value       = var.db_access_host_enabled ? aws_instance.db_access[0].id : null
+}
+
+output "db_access_host_private_ip" {
+  description = "Private IP of the SSM-managed RDS access host"
+  value       = var.db_access_host_enabled ? aws_instance.db_access[0].private_ip : null
 }
 
 output "performance_runner_instance_id" {
@@ -181,23 +211,43 @@ output "performance_results_bucket_name" {
 }
 
 output "sqs_queue_urls" {
-  description = "Source queue URLs injected into the app task definition"
+  description = "Development source queue URLs injected into the app task definition"
   value       = { for name, queue in aws_sqs_queue.source : name => queue.url }
 }
 
 output "sqs_queue_names" {
-  description = "Source queue names used by performance-run automation"
+  description = "Development source queue names"
   value       = { for name, queue in aws_sqs_queue.source : name => queue.name }
 }
 
 output "sqs_dead_letter_queue_urls" {
-  description = "Dead-letter queue URLs used by performance-run automation"
+  description = "Development dead-letter queue URLs"
   value       = { for name, queue in aws_sqs_queue.dead_letter : name => queue.url }
 }
 
 output "sqs_dead_letter_queue_names" {
-  description = "Dead-letter queue names used by performance-run automation"
+  description = "Development dead-letter queue names"
   value       = { for name, queue in aws_sqs_queue.dead_letter : name => queue.name }
+}
+
+output "performance_sqs_queue_urls" {
+  description = "Performance source queue URLs injected into the performance app task definition"
+  value       = { for name, queue in aws_sqs_queue.performance_source : name => queue.url }
+}
+
+output "performance_sqs_queue_names" {
+  description = "Performance source queue names"
+  value       = { for name, queue in aws_sqs_queue.performance_source : name => queue.name }
+}
+
+output "performance_sqs_dead_letter_queue_urls" {
+  description = "Performance dead-letter queue URLs"
+  value       = { for name, queue in aws_sqs_queue.performance_dead_letter : name => queue.url }
+}
+
+output "performance_sqs_dead_letter_queue_names" {
+  description = "Performance dead-letter queue names"
+  value       = { for name, queue in aws_sqs_queue.performance_dead_letter : name => queue.name }
 }
 
 output "ops_sns_topic_arn" {
@@ -231,6 +281,11 @@ output "rds_security_group_id" {
 output "performance_rds_security_group_id" {
   description = "Security group ID for the performance-test RDS"
   value       = aws_security_group.performance_rds.id
+}
+
+output "db_access_security_group_id" {
+  description = "Security group ID for the private SSM RDS access host"
+  value       = aws_security_group.db_access.id
 }
 
 output "vpc_endpoints_security_group_id" {
@@ -274,4 +329,9 @@ output "vpc_endpoint_ecr_api_id" {
 output "vpc_endpoint_s3_id" {
   description = "S3 Gateway VPC endpoint ID"
   value       = aws_vpc_endpoint.s3.id
+}
+
+output "alb_access_logs_bucket_name" {
+  description = "Private S3 bucket for Public and Performance ALB access logs"
+  value       = aws_s3_bucket.alb_access_logs.id
 }

--- a/terraform/performance-api-alb.tf
+++ b/terraform/performance-api-alb.tf
@@ -1,5 +1,6 @@
-# Keep the internal ALB as the explicit, SG-scoped PERF_BASE_URL path for the
-# Spot runner. NAT is reserved for external HTTPS egress, not internal API calls.
+# Keep the internal ALB as the explicit, SG-scoped path for Performance Backend
+# traffic and the Spot runner. NAT is reserved for external HTTPS egress, not
+# internal API calls.
 resource "aws_security_group" "performance_api_alb" {
   name        = "${var.project}-${var.environment}-performance-api-alb-sg"
   description = "Internal ALB that exposes GuardBench API only to the performance runner"
@@ -27,7 +28,7 @@ resource "aws_security_group_rule" "performance_api_alb_egress_to_api" {
   to_port                  = var.api_container_port
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.api.id
-  description              = "Forward performance runner API requests to ECS"
+  description              = "Forward performance workload requests to ECS"
   security_group_id        = aws_security_group.performance_api_alb.id
 }
 
@@ -48,6 +49,12 @@ resource "aws_lb" "performance_api" {
   security_groups    = [aws_security_group.performance_api_alb.id]
   subnets            = aws_subnet.private[*].id
 
+
+  access_logs {
+    bucket  = aws_s3_bucket.alb_access_logs.id
+    enabled = true
+    prefix  = "performance"
+  }
   tags = {
     Name    = "${var.project}-${var.environment}-performance-api"
     Purpose = "performance-testing"
@@ -111,8 +118,8 @@ resource "aws_lb_listener" "performance_api" {
   }
 }
 
-# Reuse the existing Runner-only internal ALB. The default action remains the
-# GuardBench backend target, so this path rule cannot alter normal API traffic.
+# Reuse the existing internal ALB. The default action targets the dedicated
+# Performance Backend service, so this path rule cannot alter normal API traffic.
 resource "aws_lb_listener_rule" "performance_demo_ai" {
   listener_arn = aws_lb_listener.performance_api.arn
   priority     = 100

--- a/terraform/performance-results.tf
+++ b/terraform/performance-results.tf
@@ -44,3 +44,129 @@ resource "aws_s3_bucket_lifecycle_configuration" "performance_results" {
     }
   }
 }
+# ALB access logs are kept separately from performance results so health-check
+# responses can be inspected without mixing operational logs with test output.
+resource "aws_s3_bucket" "alb_access_logs" {
+  bucket = "${var.project}-${var.environment}-alb-access-logs-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Name    = "${var.project}-${var.environment}-alb-access-logs"
+    Purpose = "alb-access-logging"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_access_logs" {
+  bucket = aws_s3_bucket.alb_access_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "alb_access_logs" {
+  bucket = aws_s3_bucket.alb_access_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_access_logs" {
+  bucket = aws_s3_bucket.alb_access_logs.id
+
+  rule {
+    id     = "expire-public-alb-access-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "public/"
+    }
+
+    expiration {
+      days = 7
+    }
+  }
+
+  rule {
+    id     = "expire-performance-alb-access-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "performance/"
+    }
+
+    expiration {
+      days = 7
+    }
+  }
+}
+
+data "aws_iam_policy_document" "alb_access_logs" {
+  statement {
+    sid    = "AllowElasticLoadBalancingAccessLogDelivery"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.alb_access_logs.arn}/public/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:loadbalancer/*"]
+    }
+  }
+
+  statement {
+    sid    = "AllowElasticLoadBalancingPerformanceAccessLogDelivery"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.alb_access_logs.arn}/performance/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:loadbalancer/*"]
+    }
+  }
+
+  statement {
+    sid    = "AllowElasticLoadBalancingHealthCheckLogDelivery"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+
+    actions = ["s3:PutObject"]
+    resources = [
+      "${aws_s3_bucket.alb_access_logs.arn}/health-public/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+      "${aws_s3_bucket.alb_access_logs.arn}/health-performance/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:elasticloadbalancing:${var.aws_region}:${data.aws_caller_identity.current.account_id}:loadbalancer/*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_access_logs" {
+  bucket = aws_s3_bucket.alb_access_logs.id
+  policy = data.aws_iam_policy_document.alb_access_logs.json
+}

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -60,6 +60,8 @@ resource "aws_iam_role_policy" "performance_runner" {
         Resource = concat(
           [for queue in values(aws_sqs_queue.source) : queue.arn],
           [for queue in values(aws_sqs_queue.dead_letter) : queue.arn],
+          [for queue in values(aws_sqs_queue.performance_source) : queue.arn],
+          [for queue in values(aws_sqs_queue.performance_dead_letter) : queue.arn],
         )
       },
       {

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -187,7 +187,7 @@ resource "aws_security_group_rule" "performance_rds_ingress_from_api" {
   to_port                  = var.db_port
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.api.id
-  description              = "From shared dev API service"
+  description              = "From Backend ECS services"
   security_group_id        = aws_security_group.performance_rds.id
 }
 

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -5,12 +5,15 @@ locals {
     "gb-run-finalize",
   ])
 
+  performance_queue_prefix = "${var.project}-${var.environment}-perf"
+
   # Backend dev defaults: the execution/resolution claim lease is 45s. Keep
   # enough time after the lease window for DB phase work, scheduling delay,
   # and SQS acknowledgement before a message can be delivered again.
   claim_lease_seconds        = 45
   processing_buffer_seconds  = 15
   visibility_timeout_seconds = 90
+
 }
 
 check "sqs_visibility_timeout_contract" {
@@ -45,5 +48,35 @@ resource "aws_sqs_queue" "source" {
 
   tags = {
     Name = "${var.project}-${var.environment}-${each.value}"
+  }
+}
+
+resource "aws_sqs_queue" "performance_dead_letter" {
+  for_each = local.queue_names
+
+  name                      = "${local.performance_queue_prefix}-${each.value}-dlq"
+  message_retention_seconds = 1209600
+
+  tags = {
+    Name        = "${local.performance_queue_prefix}-${each.value}-dlq"
+    Environment = "performance"
+  }
+}
+
+resource "aws_sqs_queue" "performance_source" {
+  for_each = local.queue_names
+
+  name                       = "${local.performance_queue_prefix}-${each.value}"
+  visibility_timeout_seconds = local.visibility_timeout_seconds
+  receive_wait_time_seconds  = 20
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.performance_dead_letter[each.key].arn
+    maxReceiveCount     = 5
+  })
+
+  tags = {
+    Name        = "${local.performance_queue_prefix}-${each.value}"
+    Environment = "performance"
   }
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -41,12 +41,14 @@ demo_ai_bedrock_resource_arns = [
   "arn:aws:bedrock:ap-southeast-1::foundation-model/amazon.nova-micro-v1:0",
   "arn:aws:bedrock:ap-northeast-3::foundation-model/amazon.nova-micro-v1:0",
 ]
-demo_ai_enabled       = false
+# Demo AI runs as a separate ECS service in the dev cluster and is available
+# through the internal performance ALB. Keep it enabled for normal dev use.
+demo_ai_enabled       = true
 demo_ai_desired_count = 1
 
-# The shared dev ECS task can target either the normal dev RDS or the isolated
-# performance-test RDS. Keep dev as the normal deployment default.
-ecs_db_target = "dev"
+# Dedicated Performance Backend service. Enable this for a concurrent run.
+performance_app_enabled       = false
+performance_app_desired_count = 1
 
 # Performance RDS (isolated destructive-reset target for performance tests)
 performance_db_instance_class          = "db.m7g.large"
@@ -61,3 +63,7 @@ performance_runner_instance_type  = "t3.medium"
 performance_runner_root_volume_gb = 20
 performance_runner_spot           = true
 performance_runner_enabled       = false
+
+# Private SSM host for local psql/DBeaver port forwarding to both RDS instances.
+db_access_host_enabled       = true
+db_access_host_instance_type = "t3.micro"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -93,6 +93,23 @@ variable "backend_service_desired_counts" {
   }
 }
 
+variable "performance_app_enabled" {
+  description = "Create running Performance Backend tasks alongside the development service"
+  type        = bool
+  default     = false
+}
+
+variable "performance_app_desired_count" {
+  description = "Number of Performance Backend tasks when the service is enabled"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.performance_app_desired_count >= 0
+    error_message = "performance_app_desired_count must be zero or greater."
+  }
+}
+
 variable "app_image_tag" {
   description = "Immutable ECR tag for the verified backend commit"
   type        = string
@@ -180,8 +197,20 @@ variable "db_port" {
   default     = 5432
 }
 
+variable "db_access_host_enabled" {
+  description = "Create the private SSM-managed host used for RDS port forwarding"
+  type        = bool
+  default     = true
+}
+
+variable "db_access_host_instance_type" {
+  description = "EC2 instance type for the private RDS access host"
+  type        = string
+  default     = "t3.micro"
+}
+
 variable "ecs_db_target" {
-  description = "Database target injected into the shared dev ECS task definition"
+  description = "Deprecated compatibility input; backend services no longer use a shared DB target switch"
   type        = string
   default     = "dev"
 


### PR DESCRIPTION
## Summary
- Add a private SSM-managed EC2 access host and port-forwarding documentation for Dev/Performance RDS.
- Separate Dev and Performance Backend ECS task definitions/services with fixed RDS and SQS/DLQ bindings.
- Keep Performance service opt-in (`performance_app_enabled = false` by default) so it can run alongside Dev without changing a global DB target.
- Update templates, outputs, security-group rules, logging, and operations documentation.

## Migration notes
- Existing Dev ECS service may currently reference the former Performance baseline revision. After apply, run the Dev Backend deploy workflow once so the service uses the Dev RDS/queue configuration.
- `terraform apply` is intentionally not included in this change.

## Validation
- `terraform fmt -check *.tf`
- `terraform validate`
- `git diff --check`
- AWS-backed `terraform plan`: 15 to add, 6 to change, 1 to destroy/recreate (Dev task-definition baseline only; no RDS replacement).

Fixes #31
Fixes #32