### PR TITLE
fix(terraform): preflight performance runner dependencies

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -162,6 +162,17 @@ aws ecr get-login-password --region ap-northeast-2 \
 
 Runner EC2는 ECS Optimized AL2023 AMI를 사용하므로 private subnet에서 별도 Docker 패키지 다운로드가 필요 없다. Terraform apply 후 SSM Command document를 `RunnerImage=$runner_repository:$runner_revision` 파라미터로 실행하면 ECR pull과 image `verify-runtime` 검증이 수행된다. 실제 Runner 실행에 필요한 `PERF_*` 환경변수와 profile/dataset은 Backend 성능테스트 문서의 실행 절차를 따른다.
 
+SSM bootstrap은 실제 성능 실행 전에 Runner host에서 Performance internal ALB의 `/health`와 `/api/v1/test-suites?page=1&size=1`을 확인한다. 따라서 `PERF_BASE_URL`에는 public ALB 주소를 사용하지 말고 다음 Terraform output을 사용한다.
+
+```bash
+export PERF_BASE_URL="$(terraform output -raw performance_runner_api_url)"
+export PERF_TARGET_URL="$(terraform output -raw performance_target_url)"
+export PERF_TARGET_MODEL="$(terraform output -raw performance_target_model)"
+export PERF_TARGET_REVISION="$(terraform output -raw performance_target_revision)"
+```
+
+Bootstrap은 image 안의 `/workspace/bin` script에 CRLF가 포함되어 있으면 `verify-runtime` 실행 전에 중단하고 문제 파일과 재빌드 방향을 출력한다. CRLF 오류가 발생하면 Backend Runner image를 LF checkout 환경에서 다시 build/publish하고, 배포할 image tag가 실제 image digest와 일치하는지 확인해야 한다. 현재 Performance API의 canonical health endpoint는 `/health`이며, health check가 404이면 성능 workload를 시작하지 않고 Backend image의 endpoint mapping과 image digest를 먼저 확인한다.
+
 ## 프론트엔드 GitHub Actions OIDC 배포
 
 계정에 `token.actions.githubusercontent.com` OIDC provider가 이미 있는지 먼저 확인한다.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -166,7 +166,7 @@ output "performance_runner_security_group_id" {
 }
 
 output "performance_runner_bootstrap_document_name" {
-  description = "SSM Command document that pulls and verifies the performance runner Docker image"
+  description = "SSM Command document that preflights the internal Performance API and verifies the runner Docker image"
   value       = aws_ssm_document.performance_runner_bootstrap.name
 }
 

--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -162,11 +162,16 @@ resource "aws_ssm_document" "performance_runner_bootstrap" {
       inputs = {
         runCommand = [
           "set -euo pipefail",
+          "performance_base_url='http://${aws_lb.performance_api.dns_name}'",
+          "curl --fail --silent --show-error --connect-timeout 5 --max-time 10 \"$performance_base_url/health\" >/dev/null",
+          "curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \"$performance_base_url/api/v1/test-suites?page=1&size=1\" >/dev/null",
           "runner_image='{{ RunnerImage }}'",
           "case \"$runner_image\" in \"${aws_ecr_repository.performance_runner.repository_url}:\"*) ;; *) echo 'RunnerImage must use the dedicated performance-runner ECR repository.' >&2; exit 1 ;; esac",
           "registry=\"$${runner_image%%/*}\"",
           "aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin \"$registry\"",
           "docker pull \"$runner_image\"",
+          "crlf_files=\"$(docker run --rm --entrypoint python3.11 \"$runner_image\" -c 'from pathlib import Path; print(\"\\n\".join(str(path) for path in Path(\"/workspace/bin\").rglob(\"*\") if path.is_file() and b\"\\r\\n\" in path.read_bytes()))')\"",
+          "if [ -n \"$crlf_files\" ]; then echo \"Runner image contains CRLF scripts: $crlf_files\" >&2; echo 'Rebuild and republish the image from an LF-preserving checkout.' >&2; exit 1; fi",
           "docker run --rm --entrypoint /workspace/bin/verify-runtime \"$runner_image\"",
           "install -d -m 0755 /opt/guardbench-performance-runner",
           "printf '%s\\n' \"$runner_image\" > /opt/guardbench-performance-runner/image",


### PR DESCRIPTION
## Summary
- Run the performance runner bootstrap checks against the private Performance ALB only.
- Verify `/health` and `/api/v1/test-suites?page=1&size=1` before accepting a runner image.
- Detect CRLF bytes in `/workspace/bin` before invoking `verify-runtime` and fail with actionable output.
- Document the required `PERF_BASE_URL` and target outputs.

## Scope
This Terraform change prevents an incorrect public ALB URL or a broken CRLF runner image from reaching the workload phase. The current canonical Performance API health endpoint remains `/health`; the live internal ALB and current task were verified with HTTP 200.

The source-image line-ending correction belongs in the Backend image build/publish flow. A rebuilt LF-preserving image must pass this bootstrap check before running `small --reset`.

## Validation
- `terraform fmt -check *.tf`
- `terraform validate`
- `git diff --check`
- Live runner SSM check: internal `/health` 200 and test-suite preflight 200
- Live image check: existing image failed with `bash\r`; LF-preserving `-lf` image passed

Refs #30