### PR TITLE
fix(terraform): stabilize RDS access security group rules

### DIFF
--- a/terraform/db-access.tf
+++ b/terraform/db-access.tf
@@ -11,7 +11,14 @@ resource "aws_security_group" "db_access" {
   description = "SSM-only private host for RDS port forwarding"
   vpc_id      = aws_vpc.main.id
   ingress     = []
-  egress      = []
+
+  # Egress is managed by the dedicated aws_security_group_rule resources below.
+  # Ignore the provider's default egress representation to avoid mixing inline
+  # and standalone ownership during refresh.
+  egress = []
+  lifecycle {
+    ignore_changes = [egress]
+  }
 
   tags = {
     Name    = "${var.project}-${var.environment}-db-access-sg"
@@ -67,16 +74,6 @@ resource "aws_security_group_rule" "performance_rds_ingress_from_db_access" {
   source_security_group_id = aws_security_group.db_access.id
   description              = "Developer access through SSM port forwarding"
   security_group_id        = aws_security_group.performance_rds.id
-}
-
-resource "aws_security_group_rule" "vpc_endpoints_ingress_from_db_access" {
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.db_access.id
-  description              = "SSM access host HTTPS"
-  security_group_id        = aws_security_group.vpc_endpoints.id
 }
 
 resource "aws_iam_role" "db_access" {
@@ -141,6 +138,5 @@ resource "aws_instance" "db_access" {
   depends_on = [
     aws_iam_role_policy_attachment.db_access_ssm,
     aws_security_group_rule.db_access_egress_to_vpc_endpoints,
-    aws_security_group_rule.vpc_endpoints_ingress_from_db_access,
   ]
 }

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -320,8 +320,8 @@ resource "aws_security_group" "vpc_endpoints" {
   description = "GuardBench VPC Endpoints - allow HTTPS from private subnets"
   vpc_id      = aws_vpc.main.id
 
-  # Existing state owns this inline ingress. Allow the combined app service
-  # and the dedicated performance runner, but not the legacy worker group.
+  # Existing state owns this inline ingress. Allow the private application
+  # services, the dedicated performance runner, and the RDS access host.
   ingress {
     description = "HTTPS from the combined app service"
     from_port   = 443
@@ -331,6 +331,7 @@ resource "aws_security_group" "vpc_endpoints" {
       aws_security_group.api.id,
       aws_security_group.performance_runner.id,
       aws_security_group.demo_ai.id,
+      aws_security_group.db_access.id,
     ]
   }
 


### PR DESCRIPTION
## Summary
- Keep the RDS access host egress rules under stable Terraform ownership.
- Manage the VPC Endpoint ingress source in the existing inline security-group rule.
- Prevent repeated security-group rule drift on subsequent plans.

## Why
The initial apply created the access-host rules successfully, but a post-apply plan detected mixed inline/standalone ownership. This follow-up keeps the access path unchanged while making the configuration converge cleanly.

## Validation
- `terraform fmt -check *.tf`
- `terraform validate`
- AWS-backed post-fix `terraform plan`: no changes

The corresponding AWS state correction has already been applied safely: one redundant standalone rule was removed and the VPC Endpoint SG now includes the access host.

Refs #31