### PR TITLE
fix(terraform): allow performance target access from API

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -56,6 +56,13 @@ locals {
       { name = "GUARDBENCH_SQS_QUEUE_URLS_RESOLVE", value = aws_sqs_queue.performance_source["gb-run-resolve"].url },
       { name = "GUARDBENCH_SQS_QUEUE_URLS_WORK_ITEMS", value = aws_sqs_queue.performance_source["gb-workitems"].url },
       { name = "GUARDBENCH_SQS_QUEUE_URLS_RUN_FINALIZE", value = aws_sqs_queue.performance_source["gb-run-finalize"].url },
+      {
+        name = "SPRING_APPLICATION_JSON"
+        value = jsonencode({
+          "guardbench.http-endpoint.allow-private-addresses"   = false
+          "guardbench.http-endpoint.allowed-private-hostnames" = [aws_lb.performance_api.dns_name]
+        })
+      },
     ])
     secrets = [
       { name = "SPRING_DATASOURCE_USERNAME", valueFrom = "${aws_db_instance.performance.master_user_secret[0].secret_arn}:username::" },

--- a/terraform/performance-api-alb.tf
+++ b/terraform/performance-api-alb.tf
@@ -22,6 +22,16 @@ resource "aws_security_group_rule" "performance_api_alb_ingress_from_runner" {
   security_group_id        = aws_security_group.performance_api_alb.id
 }
 
+resource "aws_security_group_rule" "performance_api_alb_ingress_from_api" {
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.api.id
+  description              = "Performance Backend target calls through the internal ALB"
+  security_group_id        = aws_security_group.performance_api_alb.id
+}
+
 resource "aws_security_group_rule" "performance_api_alb_egress_to_api" {
   type                     = "egress"
   from_port                = var.api_container_port

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -109,6 +109,16 @@ resource "aws_security_group_rule" "api_egress_to_performance_rds" {
   security_group_id        = aws_security_group.api.id
 }
 
+resource "aws_security_group_rule" "api_egress_to_performance_alb" {
+  type                     = "egress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.performance_api_alb.id
+  description              = "Performance Backend target calls through the internal ALB"
+  security_group_id        = aws_security_group.api.id
+}
+
 # ============================================
 # Worker Security Group (Orchestrator + Executor)
 # ============================================


### PR DESCRIPTION
## 변경 내용

- Performance Backend ECS가 private target hostname allowlist를 사용하도록 설정
- Performance ALB가 API Security Group의 내부 호출을 허용하도록 설정
- API Security Group이 Performance ALB(80/tcp)로 egress하도록 설정

## 검증

- Terraform apply 완료
- Performance ECS revision :3, running 1/1
- baseline-v1 78건 실행 완료 (`FINISHED`, `executionOutcome=COMPLETED`)
- executionSuccessRate 100%, Queue drain 0.073초, DLQ 0개

## 성능 결과

- k6 threshold: PASS
- 전체 acceptance: FAIL
- 백엔드 assertionPassRate: 0%, executionSuccessRate: 100%
- 결과: `s3://guardbench-dev-performance-results-508139322599/performance/results/PERF-SMALL-20260903T143956Z-70eb7837/`

Acceptance FAIL은 네트워크/실행 실패가 아니라 Demo AI 응답의 assertion 결과와 러너 acceptance metric 파싱 문제를 별도로 확인해야 합니다.