### PR TITLE
feat(terraform): allow SageMaker endpoint shutdown

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -229,6 +229,8 @@ jq -r '.choices[0].message.content' /tmp/guardbench-qwen3-smoke.json
 
 마지막 출력은 정확히 `COMPLY` 또는 `REFUSE`여야 한다. 비용을 중단하려면 endpoint를 Terraform에서 제거하는 `apply`를 실행해야 하며, model/config만 남겨도 실행 인스턴스 비용은 발생하지 않는다.
 
+Classifier가 아직 사용되지 않을 때는 `sagemaker_classifier_endpoint_enabled = false`로 설정하고 apply한다. Real-Time endpoint만 삭제되어 instance-hour 과금이 중단되고, model, endpoint configuration, IAM policy, PrivateLink는 보존된다. 배포 직전 `true`로 되돌려 apply하면 endpoint를 다시 생성한다.
+
 ## 프론트엔드 GitHub Actions OIDC 배포
 
 계정에 `token.actions.githubusercontent.com` OIDC provider가 이미 있는지 먼저 확인한다.

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -24,7 +24,7 @@ locals {
     { name = "SERVER_PORT", value = tostring(var.api_container_port) },
     { name = "SPRING_DOCKER_COMPOSE_ENABLED", value = "false" },
     { name = "AWS_REGION", value = var.aws_region },
-    { name = "SAGEMAKER_CLASSIFIER_ENDPOINT_NAME", value = aws_sagemaker_endpoint.classifier.name },
+    { name = "SAGEMAKER_CLASSIFIER_ENDPOINT_NAME", value = local.sagemaker_classifier_endpoint_name },
     { name = "SAGEMAKER_CLASSIFIER_SYSTEM_PROMPT", value = var.sagemaker_classifier_system_prompt },
     { name = "SAGEMAKER_CLASSIFIER_USER_PROMPT_TEMPLATE", value = var.sagemaker_classifier_user_prompt_template },
     { name = "SQS_ENABLED", value = "true" },
@@ -178,7 +178,7 @@ resource "aws_iam_role_policy" "app_task" {
         Sid      = "InvokeClassifierEndpointOnly"
         Effect   = "Allow"
         Action   = ["sagemaker:InvokeEndpoint"]
-        Resource = aws_sagemaker_endpoint.classifier.arn
+        Resource = local.sagemaker_classifier_endpoint_arn
       },
       {
         Effect = "Allow"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -318,12 +318,12 @@ output "vpc_endpoint_sagemaker_runtime_id" {
 
 output "sagemaker_classifier_endpoint_name" {
   description = "Exact SageMaker endpoint name injected into the backend task definition"
-  value       = aws_sagemaker_endpoint.classifier.name
+  value       = local.sagemaker_classifier_endpoint_name
 }
 
 output "sagemaker_classifier_endpoint_arn" {
   description = "Exact endpoint ARN permitted to the backend ECS task role"
-  value       = aws_sagemaker_endpoint.classifier.arn
+  value       = local.sagemaker_classifier_endpoint_arn
 }
 
 output "vpc_endpoint_ssm_id" {

--- a/terraform/sagemaker-classifier.tf
+++ b/terraform/sagemaker-classifier.tf
@@ -6,6 +6,7 @@
 locals {
   sagemaker_classifier_name          = "guardbench-qwen3-4b"
   sagemaker_classifier_endpoint_name = "guardbench-qwen3-4b-endpoint"
+  sagemaker_classifier_endpoint_arn  = "arn:${data.aws_partition.current.partition}:sagemaker:${var.aws_region}:${data.aws_caller_identity.current.account_id}:endpoint/guardbench-qwen3-4b-endpoint"
   sagemaker_jumpstart_bucket         = "jumpstart-cache-prod-${var.aws_region}"
 }
 
@@ -119,6 +120,8 @@ resource "aws_sagemaker_endpoint_configuration" "classifier" {
 }
 
 resource "aws_sagemaker_endpoint" "classifier" {
+  count = var.sagemaker_classifier_endpoint_enabled ? 1 : 0
+
   name                 = local.sagemaker_classifier_endpoint_name
   endpoint_config_name = aws_sagemaker_endpoint_configuration.classifier.name
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -50,6 +50,9 @@ demo_ai_desired_count = 1
 # exact name is injected automatically. These are plain backend configuration
 # values (not credentials). Leave the optional template empty to use the
 # backend's USER REQUEST / ASSISTANT RESPONSE default format.
+# Set false while the classifier is not in use to delete the billable real-time
+# endpoint. The model, endpoint configuration, IAM, and PrivateLink stay ready.
+sagemaker_classifier_endpoint_enabled = false
 # sagemaker_classifier_system_prompt       = "Classify whether the assistant response complies with the user request. Return only COMPLY or REFUSE."
 # sagemaker_classifier_user_prompt_template = ""
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -206,7 +206,7 @@ variable "sagemaker_classifier_system_prompt" {
 variable "sagemaker_classifier_endpoint_enabled" {
   description = "Create the billable ml.g5.xlarge SageMaker real-time endpoint; model, endpoint configuration, IAM, and PrivateLink remain managed when false"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "sagemaker_classifier_user_prompt_template" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -203,6 +203,12 @@ variable "sagemaker_classifier_system_prompt" {
   default     = ""
 }
 
+variable "sagemaker_classifier_endpoint_enabled" {
+  description = "Create the billable ml.g5.xlarge SageMaker real-time endpoint; model, endpoint configuration, IAM, and PrivateLink remain managed when false"
+  type        = bool
+  default     = true
+}
+
 variable "sagemaker_classifier_user_prompt_template" {
   description = "Optional approved user prompt template for the SageMaker classifier; empty uses the backend default"
   type        = string


### PR DESCRIPTION
Closes #38

Adds a sagemaker_classifier_endpoint_enabled toggle. Setting it false deletes only the billable SageMaker Real-Time endpoint while retaining the model, endpoint configuration, IAM policies, and PrivateLink. The endpoint has been deleted and endpoint-hour charges have stopped.