### PR TITLE
feat(terraform): separate Performance ECS capacity

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -72,6 +72,12 @@ Capacity 변경 전후에는 다음처럼 Performance Task Definition 변경만 
 terraform plan -var='performance_api_cpu=1024' -var='performance_api_memory=2048'
 ```
 
+Performance RDS는 이 ECS capacity 실험 축과 다르다. MVP에서는 workload를 Dev RDS와
+격리하기 위한 전용 DB이며, 성능 테스트 기간 동안 고정되는 의존 인프라로 운용한다.
+실제 instance class, storage, backup retention 등 구성은 재현성을 위해 결과 snapshot에
+기록하고 CloudWatch로 병목 여부를 관찰한다. RDS capacity sweep/tuning은 MVP 범위가
+아니다.
+
 ## 배포 순서
 
 ```bash
@@ -105,7 +111,7 @@ Backend `dev`의 execution/resolution claim lease 기본값은 45초이며, HTTP
 
 `maxReceiveCount = 5`는 반복되는 malformed message, application/DB 장애를 DLQ로 격리하기 위한 SQS redrive 기준이며 Provider retry budget이 아니다. Provider 호출 재시도는 Backend의 application-level attempt 정책이 소유한다. Dev와 performance-test는 별도 source queue/DLQ를 사용하지만 visibility timeout 계약은 동일하게 적용된다.
 
-Dev Backend는 Dev RDS와 Dev queue를 고정으로 사용하고, Performance Backend는 Performance RDS와 Performance queue를 고정으로 사용한다. `ecs_db_target`은 기존 `terraform.tfvars` 호환을 위해 남아 있지만 더 이상 리소스 선택에 사용하지 않는다. Performance RDS의 instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 승인된 성능 계획 값을 모두 명시해야 한다. Dev/Performance service는 shared ECS task execution/app task role을 사용하며 두 RDS secret과 두 queue 집합에 필요한 권한만 허용한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다. 외부 AI provider를 호출하는 ECS task는 private route table의 NAT Gateway와 API security group의 outbound HTTPS rule을 사용한다. AWS Bedrock 등 VPC Endpoint가 지원하는 서비스는 기존 private endpoint를 우선 사용한다.
+Dev Backend는 Dev RDS와 Dev queue를 고정으로 사용하고, Performance Backend는 Performance RDS와 Performance queue를 고정으로 사용한다. `ecs_db_target`은 기존 `terraform.tfvars` 호환을 위해 남아 있지만 더 이상 리소스 선택에 사용하지 않는다. Performance RDS는 MVP의 격리된 고정 의존 인프라다. instance class, storage, backup retention 변수에는 default가 없으므로 적용 전에 고정할 구성 값을 모두 명시해야 하며, 실제 적용값은 재현성을 위해 기록하고 CloudWatch로 병목 여부를 관찰한다. RDS capacity sweep/tuning은 MVP 범위가 아니다. Dev/Performance service는 shared ECS task execution/app task role을 사용하며 두 RDS secret과 두 queue 집합에 필요한 권한만 허용한다. credential은 Terraform output이나 task definition plaintext에 노출하지 않는다. 외부 AI provider를 호출하는 ECS task는 private route table의 NAT Gateway와 API security group의 outbound HTTPS rule을 사용한다. AWS Bedrock 등 VPC Endpoint가 지원하는 서비스는 기존 private endpoint를 우선 사용한다.
 
 전용 Performance Runner EC2는 `performance_runner_enabled = false`가 기본값이며 일반적인 `dev` 배포에서는 생성하지 않는다. Backend의 `performance/build-runner-image.sh`로 이미지를 빌드하고 Terraform output의 전용 ECR repository에 Backend commit SHA tag로 push한 뒤, 성능 테스트를 실행할 때만 이 값을 `true`로 설정하고 Terraform apply를 수행한다. Spot runner는 `one-time` 요청이므로 테스트 종료 후 인스턴스를 삭제하거나 중단하면 다음 테스트 전에 다시 apply해야 한다.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -53,6 +53,25 @@ terraform apply
 
 현재 결합 서비스의 `app` 값 변경은 `aws_ecs_service.app`의 `desired_count`만 갱신하며 task definition이나 다른 서비스의 capacity를 변경하지 않는다. `terraform plan`에서 이 변경이 의도한 ECS Service update인지 확인한 뒤 apply한다.
 
+Performance Backend의 Infrastructure Capacity는 Dev API와 독립된
+`performance_api_cpu`/`performance_api_memory` 입력으로 관리한다. 기본값은 기존
+Performance Task Definition과 같은 512 CPU units / 1024 MiB이며, 실제 최적값을 의미하지
+않는다. 이 값을 변경하면 `aws_ecs_task_definition.performance_app`만 새 CPU/memory로
+등록되고 Dev Task Definition/Service에는 변경이 없어야 한다. Backend #193 snapshot은
+Profile/Workload 값이 아니라 AWS에 적용된 active Performance Task Definition의
+`ecs.task_cpu`와 `ecs.task_memory`를 기록한다.
+
+```hcl
+performance_api_cpu    = 1024
+performance_api_memory = 2048
+```
+
+Capacity 변경 전후에는 다음처럼 Performance Task Definition 변경만 포함되는지 확인한다.
+
+```bash
+terraform plan -var='performance_api_cpu=1024' -var='performance_api_memory=2048'
+```
+
 ## 배포 순서
 
 ```bash

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -228,8 +228,8 @@ resource "aws_ecs_task_definition" "performance_app" {
   family                   = "${var.project}-${var.environment}-performance-app"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = var.api_cpu
-  memory                   = var.api_memory
+  cpu                      = var.performance_api_cpu
+  memory                   = var.performance_api_memory
 
   runtime_platform {
     cpu_architecture        = "X86_64"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -66,7 +66,9 @@ performance_app_desired_count = 1
 performance_api_cpu    = 512
 performance_api_memory = 1024
 
-# Performance RDS (isolated destructive-reset target for performance tests)
+# Performance RDS is an isolated, fixed dependency for MVP performance tests.
+# Keep its configured values stable; record them for reproducibility and observe
+# CloudWatch metrics for bottleneck detection. Capacity sweep/tuning is out of scope.
 performance_db_instance_class          = "db.m7g.large"
 performance_db_allocated_storage       = 20
 performance_db_max_allocated_storage   = 100

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -60,6 +60,12 @@ sagemaker_classifier_endpoint_enabled = false
 performance_app_enabled       = false
 performance_app_desired_count = 1
 
+# Performance Infrastructure Capacity is independent from the Dev API task.
+# These values are recorded in the active ECS Task Definition and in the
+# performance result capacity snapshot; they are not Profile/Workload inputs.
+performance_api_cpu    = 512
+performance_api_memory = 1024
+
 # Performance RDS (isolated destructive-reset target for performance tests)
 performance_db_instance_class          = "db.m7g.large"
 performance_db_allocated_storage       = 20

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,6 +79,28 @@ variable "api_memory" {
   default     = 1024
 }
 
+variable "performance_api_cpu" {
+  description = "CPU units for the independent Performance Backend task (1 vCPU = 1024)"
+  type        = number
+  default     = 512
+
+  validation {
+    condition     = var.performance_api_cpu > 0 && var.performance_api_cpu == floor(var.performance_api_cpu)
+    error_message = "performance_api_cpu must be a positive whole number."
+  }
+}
+
+variable "performance_api_memory" {
+  description = "Memory (MiB) for the independent Performance Backend task"
+  type        = number
+  default     = 1024
+
+  validation {
+    condition     = var.performance_api_memory > 0 && var.performance_api_memory == floor(var.performance_api_memory)
+    error_message = "performance_api_memory must be a positive whole number."
+  }
+}
+
 variable "backend_service_desired_counts" {
   description = "Desired task counts keyed by backend ECS service role; app is the current combined service and api/worker are available for the future split"
   type        = map(number)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -285,17 +285,17 @@ variable "dev_db_backup_retention_period" {
 }
 
 variable "performance_db_instance_class" {
-  description = "Required instance class for the performance-test RDS, set from the approved test sizing decision"
+  description = "Instance class for the isolated, fixed Performance RDS dependency used by MVP tests; record the applied value for reproducibility and observe it for bottlenecks. RDS capacity sweep/tuning is outside MVP scope."
   type        = string
 }
 
 variable "performance_db_allocated_storage" {
-  description = "Required allocated storage in GiB for the performance-test RDS"
+  description = "Configured allocated storage in GiB for the isolated, fixed Performance RDS MVP dependency; record the applied value for reproducibility. RDS capacity sweep/tuning is outside MVP scope."
   type        = number
 }
 
 variable "performance_db_max_allocated_storage" {
-  description = "Required maximum autoscaled storage in GiB for the performance-test RDS"
+  description = "Configured maximum allocated storage in GiB for the isolated, fixed Performance RDS MVP dependency; record the applied value for reproducibility. RDS capacity sweep/tuning is outside MVP scope."
   type        = number
 
   validation {
@@ -305,7 +305,7 @@ variable "performance_db_max_allocated_storage" {
 }
 
 variable "performance_db_backup_retention_period" {
-  description = "Required backup retention period in days for the performance-test RDS"
+  description = "Configured backup retention period in days for the isolated, fixed Performance RDS MVP dependency; record the applied value for reproducibility. RDS capacity sweep/tuning is outside MVP scope."
   type        = number
 }
 


### PR DESCRIPTION
## 관련 Issue

Closes #41

관련 Backend 계약: GuardBench/guardbench-backend#200, PR #203

## 변경 내용

- Performance ECS Task Definition에 `performance_api_cpu`와 `performance_api_memory` 전용 입력을 추가했습니다.
- Dev ECS Task Definition은 기존 `api_cpu`/`api_memory`를 계속 사용합니다.
- Performance capacity 입력을 `terraform.tfvars.example`와 운영 README에 문서화했습니다.
- Performance RDS는 MVP에서 workload 격리를 위한 고정 의존 인프라임을 명확히 했습니다.
- RDS 실제 구성은 재현성을 위해 기록하고 CloudWatch로 병목을 관찰하며, RDS capacity sweep/tuning은 MVP 범위에서 제외했습니다.
- 기존 Performance RDS resource와 입력, 기본값/실제 sizing 값은 변경하지 않았습니다.

## 커밋 구성

1. `feat(terraform): separate performance task capacity`
2. `docs(terraform): clarify fixed Performance RDS scope`

## 검증

- `terraform fmt -check` 통과
- `terraform validate` 통과
- AWS credential profile(`terraform`)로 기본 `terraform plan` 실행: `No changes`
- `performance_api_cpu=1024`, `performance_api_memory=2048` 가상 plan: Performance Task Definition만 교체 대상이며 Dev Task Definition/Service 변경 없음
- 후속 문서/description 변경 후 plan: `No changes`; Performance RDS 변경 없음

Terraform apply는 실행하지 않았습니다.
