### PR TITLE
docs(terraform): clarify Demo AI performance fixture role

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -179,6 +179,8 @@ terraform output -raw performance_ecs_service_name
 
 ## Demo AI dev/성능 테스트 Target
 
+Demo AI is a controlled synthetic customer Application Target used to isolate GuardBench performance measurements from external service variability. 실제 고객의 OpenAI-compatible Application Target을 대신하는 고정 fixture이며 GuardBench 자체의 SUT가 아니다. Demo AI 자체의 최대 throughput, CPU saturation, scaling 특성을 측정하지 않으며, Demo AI의 CPU/memory/desired count를 MVP GuardBench capacity sweep 대상으로 사용하지 않는다.
+
 Demo AI는 기존 `guardbench-dev-cluster`를 재사용하는 별도 Fargate Task Definition/Service다. Backend `guardbench-dev-app` 또는 `guardbench-dev-performance-app`의 sidecar가 아니며, 전용 task role·execution role·CloudWatch Log Group·security group을 사용한다. Demo AI image는 `guardbench-demo-ai-service` 전용 ECR repository의 immutable Git SHA tag로 지정한다. dev에서 통합 target으로 사용하므로 예제 설정은 `demo_ai_enabled = true`이며, 비용 절감이나 일시 중지가 필요할 때만 `false`로 바꾼다.
 
 기존 `guardbench-dev-performance-api` internal ALB를 재사용하고 `/v1/chat/completions` path rule만 Demo AI target group으로 전달한다. 기존 ALB default action과 Backend target group은 변경하지 않는다. ALB health check는 Demo AI의 `GET /health`를 사용한다. Runner SG에서 internal ALB SG로 HTTP 80, ALB SG에서 Demo AI task SG로 TCP 8080만 허용되며, Demo AI task는 private subnet에서 `assign_public_ip = false`로 실행된다.
@@ -203,7 +205,7 @@ terraform output -raw performance_target_model
 terraform output -raw performance_target_revision
 ```
 
-이는 각각 `PERF_TARGET_URL`, `PERF_TARGET_MODEL`, `PERF_TARGET_REVISION`에 매핑된다. 현재 값은 `http://<internal-performance-alb>/v1/chat/completions`, `demo-model`, Demo AI immutable image tag다. Runner는 Demo AI container를 실행하지 않고 HTTP client 역할만 수행한다.
+이는 각각 `PERF_TARGET_URL`, `PERF_TARGET_MODEL`, `PERF_TARGET_REVISION`에 매핑된다. 현재 값은 `http://<internal-performance-alb>/v1/chat/completions`, `demo-model`, Demo AI immutable image tag다. Runner는 Demo AI container를 실행하지 않고 HTTP client 역할만 수행한다. 비교 가능한 실험에서는 Demo AI image/revision, model/config, ECS CPU/memory, desired count, endpoint와 가능한 한 동일한 latency 특성을 고정한다. 이 조건이 바뀐 실행은 GuardBench capacity 변경 전후의 동일 조건 비교로 간주하지 않는다. Application Target은 workload가 호출할 target을 지정할 뿐 target capacity를 GuardBench 실험 축으로 소유하지 않는다.
 
 ```bash
 runner_repository="$(terraform output -raw performance_runner_ecr_repository_url)"

--- a/terraform/demo-ai.tf
+++ b/terraform/demo-ai.tf
@@ -1,4 +1,6 @@
 # OpenAI-compatible Demo AI target for integrated performance tests.
+# Demo AI is a controlled synthetic customer Application Target used to
+# isolate GuardBench performance measurements from external service variability.
 # This service deliberately has its own task definition, service, task role,
 # execution role, log group, and security group. It reuses the existing dev
 # ECS cluster and private subnets but never becomes a backend sidecar.

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -178,19 +178,19 @@ variable "demo_ai_bedrock_resource_arns" {
 }
 
 variable "demo_ai_cpu" {
-  description = "CPU units for the Demo AI Fargate task"
+  description = "CPU units for the fixed Demo AI Fargate fixture; keep stable during GuardBench capacity experiments and do not use for MVP capacity sweeps"
   type        = number
   default     = 512
 }
 
 variable "demo_ai_memory" {
-  description = "Memory (MiB) for the Demo AI Fargate task"
+  description = "Memory (MiB) for the fixed Demo AI Fargate fixture; keep stable during GuardBench capacity experiments and do not use for MVP capacity sweeps"
   type        = number
   default     = 1024
 }
 
 variable "demo_ai_desired_count" {
-  description = "Number of Demo AI Fargate tasks used as the performance-test target"
+  description = "Number of Demo AI Fargate fixture tasks; keep stable during GuardBench capacity experiments and do not use for MVP capacity sweeps"
   type        = number
   default     = 1
 


### PR DESCRIPTION
## 관련 Issue

Refs #41

## 결과

- Demo AI를 외부 고객 서비스 variability를 통제하는 fixed synthetic Application Target으로 명확히 정의했습니다.
- Demo AI 자체의 throughput, CPU saturation, scaling을 측정하지 않으며 MVP GuardBench capacity sweep 대상이 아님을 문서화했습니다.
- demo_ai_cpu, demo_ai_memory, demo_ai_desired_count를 Performance 환경에서 고정할 fixture 구성값으로 설명했습니다.

## 변경 및 Non-Goals

- terraform/demo-ai.tf 주석에 controlled synthetic customer Application Target 역할을 추가했습니다.
- terraform/variables.tf의 Demo AI CPU/memory/desired count description을 고정 fixture 및 capacity sweep 제외 의미로 갱신했습니다.
- terraform/README.md에 역할, 비교 조건, Application Target capacity 소유 경계를 추가했습니다.
- Demo AI ECS resource, Terraform input, deployment 구조, application code, artificial delay/throttling, autoscaling, benchmark는 변경하지 않았습니다.

## 계약과 호환성 영향

- [x] 없음
- [ ] 공개 API
- [ ] 도메인
- [ ] DB 또는 마이그레이션
- [ ] production 의존성
- [ ] 아키텍처
- [ ] 보안 또는 운영

승인 근거와 호환성·배포·롤백 고려사항:

- Backend 성능 테스트 계약의 Demo AI 고정 fixture 역할과 ECS/SageMaker capacity 실험 경계를 따랐습니다.
- Terraform resource expression과 input 이름을 변경하지 않아 infrastructure plan상 resource 변경이 없어야 합니다.
- 최신 dev 기준 clean worktree에서 Demo AI 문서 커밋만 분리했으며, 기존 RDS 작업 branch의 변경은 포함하지 않았습니다.

## 검증

| 명령 또는 확인 | 결과 |
| --- | --- |
| terraform fmt -check | PASS |
| terraform validate | PASS |
| Demo AI 변경 branch git diff --check | PASS |
| Demo AI targeted terraform plan | AWS S3 backend credential 만료로 미실행 |

미검증 항목과 이유:

- 실제 AWS credential 재인증 전에는 targeted plan의 No changes 결과를 확인하지 못했습니다.
- Terraform apply는 실행하지 않았습니다.

## 구현 판단과 리뷰 포인트

- Demo AI의 image/revision, model/config, ECS CPU/memory, desired count, endpoint와 latency 특성은 GuardBench capacity 비교 중 고정되어야 합니다.
- Application Target은 workload가 호출할 target을 지정할 뿐 target capacity를 GuardBench 실험 축으로 소유하지 않습니다.
- Plan 검증은 AWS credential 재인증 후 Demo AI ECS resource에 대한 targeted plan으로 재확인해야 합니다.

## 작성자 확인

- [x] Issue 전용 clean worktree와 agent/{issue-number}-{slug} 브랜치에서 작업했습니다. 최신 dev 기반 agent/demo-ai-performance-fixture branch를 사용했습니다.
- [x] Issue의 범위와 Non-Goals를 다시 확인했고, 변경된 파일이 범위와 일치함을 점검했습니다.
- [x] 독립 검토 가능한 Docs/Config 리뷰 단위 커밋으로 로컬 커밋했습니다.
- [x] APPROVED 계약을 지켰고 resource/API/DB/architecture 변경은 없습니다.
- [x] push 직전 커밋 로그, 파일 통계, committed diff 범위를 검증했습니다.
- [x] 전체 diff·commit·검증 결과를 확인했고 미검증 항목을 기록했습니다.
- [x] 현재 PR/Issue와 무관한 이슈, 다른 worktree, 다른 커밋을 설명에 불필요하게 언급하지 않았습니다.
- [x] 비밀 정보, 자격 증명, 개인정보 또는 운영 데이터를 포함하지 않았습니다.