### PR TITLE
fix(terraform): align Performance OIDC subject

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -362,7 +362,7 @@ Performance 전용 deploy role은 지정된 ECR repository push,
 `guardbench-dev-performance-app` task definition family 등록, Performance service 조회·갱신,
 ECS execution/app task role에 대한 제한된 `iam:PassRole`만 허용한다. Performance role의
 OIDC trust subject는 정확히
-`repo:GuardBench/guardbench-backend:environment:performance`이며, GitHub Environment의
+`repo:GuardBench@316853045/guardbench-backend@1333885107:environment:performance`이며, GitHub Environment의
 Allowed branch는 `dev`로 제한해야 한다. Task definition tags를 workflow에서 전달하지 않으므로
 `ecs:TagResource`는 부여하지 않는다.
 

--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -235,7 +235,12 @@ data "aws_iam_policy_document" "backend_performance_github_actions_assume_role" 
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:GuardBench/guardbench-backend:environment:performance"]
+      # GuardBench customizes GitHub OIDC subjects with immutable organization
+      # and repository IDs. The performance Environment is branch-restricted
+      # to dev in GitHub settings, so the environment subject is sufficient.
+      values = [
+        "repo:GuardBench@316853045/guardbench-backend@1333885107:environment:performance",
+      ]
     }
   }
 }


### PR DESCRIPTION
## 긴급 배포 수정

Performance Backend GitHub Actions가 `sts:AssumeRoleWithWebIdentity`에서 거부되는 문제를 수정합니다.

## 원인

GuardBench GitHub OIDC subject가 immutable organization/repository ID 형식을 사용하는데, Performance deploy role만 일반 repository/name subject를 신뢰하고 있었습니다.

## 변경

Performance role trust subject를 다음 값으로 정렬했습니다.

```text
repo:GuardBench@316853045/guardbench-backend@1333885107:environment:performance
```

README의 운영 계약 예시도 같은 값으로 갱신했습니다.

## 영향 범위

- IAM Performance GitHub Actions deploy role trust policy in-place update
- ECS/RDS/SageMaker 리소스 변경 없음
- Backend `performance` Environment와 `dev` branch policy는 유지

## 검증

- `terraform fmt`
- `terraform validate`
- `git diff --check`
- GitHub `performance` Environment variable/branch policy 확인

병합 전에도 이 작업 트리로 Terraform apply하면 AWS IAM trust policy가 반영되어 Backend OIDC 배포를 재시도할 수 있습니다.
