### PR TITLE
fix(performance): provide runner control-plane access

### DIFF
--- a/terraform/performance-runner.tf
+++ b/terraform/performance-runner.tf
@@ -54,6 +54,18 @@ resource "aws_iam_role_policy" "performance_runner" {
         Resource = "*"
       },
       {
+        Sid    = "ReadPerformanceCapacity"
+        Effect = "Allow"
+        Action = [
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "rds:DescribeDBInstances",
+          "sagemaker:DescribeEndpoint",
+          "sagemaker:DescribeEndpointConfig",
+        ]
+        Resource = "*"
+      },
+      {
         Sid    = "ReadPerformanceQueueMetrics"
         Effect = "Allow"
         Action = ["sqs:GetQueueAttributes"]

--- a/terraform/vpc-endpoints.tf
+++ b/terraform/vpc-endpoints.tf
@@ -6,6 +6,48 @@
 
 # --- Interface Endpoints (PrivateLink) ---
 
+# AWS Control Plane APIs used by the private Performance Runner capacity snapshot.
+# Keep these as dedicated endpoints instead of opening the Runner SG to the NAT
+# gateway; the existing endpoint SG already allows HTTPS from the Runner SG.
+resource "aws_vpc_endpoint" "ecs" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.ecs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-ecs"
+  }
+}
+
+resource "aws_vpc_endpoint" "rds" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.rds"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-rds"
+  }
+}
+
+resource "aws_vpc_endpoint" "sagemaker_api" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${var.aws_region}.sagemaker.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project}-${var.environment}-vpce-sagemaker-api"
+  }
+}
+
 # SQS - 메시지 큐 (gb-run-resolve, gb-workitems, gb-run-finalize)
 resource "aws_vpc_endpoint" "sqs" {
   vpc_id              = aws_vpc.main.id


### PR DESCRIPTION
## 요약

Private Performance Runner가 capacity snapshot을 수행할 수 있도록 AWS Control Plane 접근 경로와 최소 read-only 권한을 추가합니다.

## 변경 사항

- ECS Interface VPC Endpoint 추가
- RDS Interface VPC Endpoint 추가
- SageMaker API Interface VPC Endpoint 추가
- Runner role에 ECS/RDS/SageMaker capacity 조회 read-only 권한 추가
- 기존 Runner SG와 VPC endpoint SG 규칙을 재사용
- NAT 전체 개방 없이 private DNS 기반 경로 사용

## 검증

- terraform validate: PASS
- endpoint targeted plan: 3 to add, 0 to change, 0 to destroy
- endpoint targeted apply: 3 added, 0 changed, 0 destroyed
- IAM targeted plan: 0 to add, 1 to change, 0 to destroy
- IAM targeted apply: 0 added, 1 changed, 0 destroyed
- 실제 endpoint 상태: ecs, rds, sagemaker.api 모두 available
- 실제 Runner capacity snapshot: PASS
  - ECS desired/running 1/1, CPU 512, memory 1024
  - RDS db.m7g.large
  - SageMaker AllTraffic, ml.g5.xlarge, desired/current 1/1

## 영향 및 Non-Goals

- Backend ECS application service는 재배포하지 않았습니다.
- 기존 사용자 변경사항인 CloudFront, GitHub OIDC, README 변경은 포함하지 않았습니다.
- Interface Endpoint 3개가 2개 AZ에 생성되어 endpoint hourly/data processing 비용이 발생합니다.
- companion Backend PR: https://github.com/GuardBench/guardbench-backend/pull/207

## 롤백

Runner 사용을 중지할 때 endpoint와 IAM policy statement를 되돌리는 별도 Terraform 변경으로 롤백합니다. 현재 성능 테스트 실행을 위해 endpoint와 권한을 유지합니다.