### PR TITLE
fix: Backend GitHub deploy Role에 ECR repository 조회 권한 추가

### DIFF
--- a/terraform/github-oidc.tf
+++ b/terraform/github-oidc.tf
@@ -153,6 +153,7 @@ data "aws_iam_policy_document" "backend_github_actions_deploy" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
       "ecr:UploadLayerPart",


### PR DESCRIPTION
## Summary

- Backend GitHub deploy Role의 ECR repository-scoped statement에 `ecr:DescribeRepositories`를 추가합니다.
- Backend CI 배포의 `aws ecr describe-repositories` AccessDenied를 해결합니다.

## Validation

- `terraform fmt -check`
- `terraform validate`
- targeted plan: `0 to add, 1 to change, 0 to destroy`
- 대상: `aws_iam_role_policy.backend_github_actions_deploy` only

전체 plan에는 오래된 로컬 tfvars로 인한 무관한 변경이 포함되어 적용하지 않았습니다. 현재 Backend task 값을 보존한 targeted plan만 검증했습니다.

Closes #48

## Applied validation

- dev targeted apply: `0 added, 1 changed, 0 destroyed`
- AWS inline policy verification: `ecr:DescribeRepositories = true`
- Backend CI rerun (attempt 2): success
- deployed backend commit: `509014a3cf5defe3a04848fc0f61daec69df8599`
- ECS service: task definition `guardbench-dev-app:33`, steady state, running 1/1
- CloudFront smoke: `/api/v1/test-runs/1/comparisons/2/summary` reached the new route and returned the expected `TEST_RUN_NOT_FOUND` envelope (dev currently has no TestRun rows)

Backend CI: https://github.com/GuardBench/guardbench-backend/actions/runs/33955086289